### PR TITLE
Attach lesson URLs dynamically in Lingo API

### DIFF
--- a/Lingo/A1-1.html
+++ b/Lingo/A1-1.html
@@ -1,0 +1,1021 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <title>Nomen &amp; Artikel · A1</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --accent: #58cc02;
+        --accent-dark: #45a402;
+        --surface: rgba(255, 255, 255, 0.92);
+        --surface-strong: rgba(255, 255, 255, 0.98);
+        --text-primary: #032b2f;
+        --text-secondary: rgba(3, 43, 47, 0.7);
+        --shadow: 0 16px 35px rgba(38, 132, 13, 0.25);
+      }
+
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+
+      html,
+      body {
+        padding: 0;
+        margin: 0;
+        width: 100%;
+        height: 100%;
+        font-family: "SF Pro Text", "SF Pro Display", -apple-system, BlinkMacSystemFont,
+          "Segoe UI", Roboto, sans-serif;
+        background: linear-gradient(160deg, #e9f9d9 0%, #f8fff1 25%, #e2f7ff 100%);
+        color: var(--text-primary);
+        -webkit-font-smoothing: antialiased;
+        -webkit-text-size-adjust: 100%;
+        user-select: none;
+        -webkit-user-select: none;
+        -webkit-touch-callout: none;
+        touch-action: manipulation;
+        overscroll-behavior-y: contain;
+      }
+
+      body {
+        display: flex;
+        justify-content: center;
+        align-items: stretch;
+        padding: 20px 16px 64px;
+      }
+
+      .app {
+        width: min(460px, 100%);
+        display: flex;
+        flex-direction: column;
+        gap: 20px;
+      }
+
+      header.hero {
+        background: var(--surface);
+        border-radius: 28px;
+        padding: 28px 24px;
+        box-shadow: var(--shadow);
+        position: relative;
+        overflow: hidden;
+      }
+
+      header.hero::after {
+        content: "";
+        position: absolute;
+        inset: -80px -40px auto auto;
+        width: 200px;
+        height: 200px;
+        background: radial-gradient(circle at top left, rgba(255, 255, 255, 0.7), transparent 70%);
+        pointer-events: none;
+      }
+
+      .lesson-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        font-size: 14px;
+        font-weight: 600;
+        letter-spacing: 0.01em;
+        padding: 6px 14px;
+        border-radius: 999px;
+        background: rgba(88, 204, 2, 0.15);
+        color: var(--accent-dark);
+        text-transform: uppercase;
+      }
+
+      h1 {
+        margin: 18px 0 10px;
+        font-size: clamp(26px, 6vw, 34px);
+        line-height: 1.1;
+        letter-spacing: -0.02em;
+      }
+
+      .hero p {
+        margin: 0;
+        font-size: 16px;
+        line-height: 1.55;
+        color: var(--text-secondary);
+      }
+
+      .badge-row {
+        display: flex;
+        gap: 10px;
+        margin-top: 22px;
+        flex-wrap: wrap;
+      }
+
+      .badge {
+        background: var(--surface-strong);
+        border-radius: 16px;
+        padding: 10px 14px;
+        font-size: 13px;
+        font-weight: 600;
+        color: var(--accent-dark);
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        box-shadow: 0 8px 16px rgba(69, 164, 2, 0.15);
+      }
+
+      .badge svg {
+        width: 18px;
+        height: 18px;
+        fill: var(--accent);
+      }
+
+      section {
+        background: var(--surface);
+        border-radius: 26px;
+        padding: 24px 22px;
+        box-shadow: 0 18px 45px rgba(31, 116, 7, 0.12);
+        backdrop-filter: blur(12px);
+      }
+
+      section h2 {
+        margin: 0 0 16px;
+        font-size: 22px;
+      }
+
+      .pattern-grid,
+      .practice-grid,
+      .tip-grid {
+        display: grid;
+        gap: 14px;
+      }
+
+      .pattern-card,
+      .tip-card,
+      .practice-card {
+        background: var(--surface-strong);
+        border-radius: 22px;
+        padding: 18px 18px 20px;
+        position: relative;
+        overflow: hidden;
+      }
+
+      .pattern-card::before,
+      .tip-card::before,
+      .practice-card::before {
+        content: "";
+        position: absolute;
+        inset: auto -40px -60px auto;
+        width: 160px;
+        height: 160px;
+        background: radial-gradient(circle, rgba(88, 204, 2, 0.12), transparent 65%);
+        pointer-events: none;
+      }
+
+      .pattern-card h3,
+      .practice-card h3,
+      .tip-card h3 {
+        margin: 0 0 12px;
+        font-size: 18px;
+        letter-spacing: -0.01em;
+      }
+
+      .pattern-card p,
+      .tip-card p,
+      .practice-card p {
+        margin: 0;
+        font-size: 15px;
+        line-height: 1.5;
+        color: var(--text-secondary);
+      }
+
+      .example {
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+        margin-top: 14px;
+        background: rgba(88, 204, 2, 0.12);
+        color: var(--text-primary);
+        padding: 12px 14px;
+        border-radius: 18px;
+        font-weight: 600;
+        font-size: 15px;
+      }
+
+      .example small {
+        font-weight: 500;
+        color: var(--text-secondary);
+      }
+
+      .story-card {
+        background: var(--surface-strong);
+        border-radius: 22px;
+        padding: 20px 18px;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+
+      .story-line {
+        display: flex;
+        gap: 12px;
+        align-items: flex-start;
+      }
+
+      .story-line span {
+        width: 28px;
+        height: 28px;
+        border-radius: 10px;
+        background: rgba(88, 204, 2, 0.18);
+        color: var(--accent-dark);
+        font-weight: 700;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        flex-shrink: 0;
+      }
+
+      .story-line p {
+        margin: 0;
+        font-size: 15px;
+        line-height: 1.5;
+        color: var(--text-primary);
+      }
+
+      .chip-row {
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+        margin-top: 14px;
+      }
+
+      .chip {
+        padding: 10px 14px;
+        border-radius: 999px;
+        border: 2px solid transparent;
+        background: rgba(255, 255, 255, 0.85);
+        font-size: 15px;
+        font-weight: 600;
+        color: var(--text-primary);
+        transition: border 0.2s ease, background 0.2s ease, transform 0.2s ease;
+        min-width: 72px;
+        text-align: center;
+      }
+
+      .chip:active {
+        transform: scale(0.96);
+      }
+
+      .chip.selected {
+        border-color: var(--accent);
+        background: rgba(88, 204, 2, 0.18);
+      }
+
+      .chip.correct {
+        border-color: #0f9553;
+        background: rgba(15, 149, 83, 0.18);
+        color: #0f9553;
+      }
+
+      .chip.incorrect {
+        border-color: #ff7a5a;
+        background: rgba(255, 122, 90, 0.12);
+        color: #ba3a24;
+      }
+
+      .progress {
+        margin-top: 16px;
+        height: 10px;
+        border-radius: 999px;
+        background: rgba(3, 43, 47, 0.08);
+        overflow: hidden;
+      }
+
+      .progress span {
+        display: block;
+        height: 100%;
+        width: 0;
+        background: linear-gradient(90deg, var(--accent), #8be80a);
+        border-radius: inherit;
+        transition: width 0.4s ease;
+      }
+
+      footer {
+        margin-top: 10px;
+        font-size: 12px;
+        text-align: center;
+        color: rgba(3, 43, 47, 0.45);
+      }
+
+      .floating-action {
+        position: fixed;
+        right: 18px;
+        bottom: 24px;
+        background: var(--accent);
+        color: white;
+        border-radius: 22px;
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+        padding: 16px 18px;
+        box-shadow: 0 18px 35px rgba(88, 204, 2, 0.35);
+        font-weight: 700;
+        letter-spacing: 0.01em;
+        border: none;
+        font-size: 16px;
+        text-decoration: none;
+      }
+
+      .floating-action:active {
+        transform: scale(0.98);
+      }
+
+      @media (max-width: 414px) {
+        header.hero,
+        section {
+          padding: 22px 18px;
+          border-radius: 24px;
+        }
+
+        .pattern-card,
+        .practice-card,
+        .tip-card,
+        .story-card {
+          border-radius: 20px;
+        }
+
+        .floating-action {
+          bottom: 20px;
+          right: 16px;
+          padding: 14px 16px;
+          font-size: 15px;
+        }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        *,
+        *::before,
+        *::after {
+          animation-duration: 0.01ms !important;
+          animation-iteration-count: 1 !important;
+          transition-duration: 0.01ms !important;
+          scroll-behavior: auto !important;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="app" aria-live="polite">
+      <header class="hero">
+        <span class="lesson-chip" data-i18n="lessonTag">A1 · Lektion 1</span>
+        <h1 data-i18n="title">Nomen &amp; Artikel</h1>
+        <p data-i18n="description">
+          Bestimmte/Unbestimmte Artikel, Pluralbildung, Verneinung mit „kein/keine“.
+        </p>
+        <div class="badge-row">
+          <span class="badge" data-i18n="badgeArticle">
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 4c-.55 0-1 .45-1 1v14c0 .55.45 1 1 1h12c.55 0 1-.45 1-1V5c0-.55-.45-1-1-1H6zm6 3.5 3.5 6h-7l3.5-6z"/></svg>
+            Artikel
+          </span>
+          <span class="badge" data-i18n="badgePlural">
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3 2 9l10 6 10-6-10-6zm0 9.09L5.47 9 12 4.91 18.53 9 12 12.09zM2 15l10 6 10-6-2.53-1.52L12 18.09 4.53 13.48 2 15z"/></svg>
+            Plural
+          </span>
+          <span class="badge" data-i18n="badgeNegation">
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2a10 10 0 1 0 10 10A10.011 10.011 0 0 0 12 2Zm0 4a6 6 0 0 1 3.46 1.09L7.09 15.46A6 6 0 0 1 12 6Zm0 12a6 6 0 0 1-3.46-1.09l8.37-8.37A6 6 0 0 1 12 18Z"/></svg>
+            kein/keine
+          </span>
+        </div>
+      </header>
+
+      <section aria-labelledby="patterns-heading">
+        <h2 id="patterns-heading" data-i18n="patternsHeading">Schlüsselstrukturen</h2>
+        <div class="pattern-grid">
+          <article class="pattern-card">
+            <h3>der / die / das + Nomen</h3>
+            <p>
+              Verwende den bestimmten Artikel, wenn alle wissen, wovon du sprichst.
+            </p>
+            <div class="example">
+              <span>der Tisch</span>
+              <small>Maskulin · Singular</small>
+            </div>
+          </article>
+          <article class="pattern-card">
+            <h3>ein / eine + Nomen</h3>
+            <p>
+              Verwende den unbestimmten Artikel für etwas Neues oder Unbekanntes.
+            </p>
+            <div class="example">
+              <span>eine Lampe</span>
+              <small>Feminin · Singular</small>
+            </div>
+          </article>
+          <article class="pattern-card">
+            <h3>kein / keine + Nomen</h3>
+            <p>
+              „kein“ ersetzt den Artikel in negativen Aussagen und stimmt in Genus und Numerus.
+            </p>
+            <div class="example">
+              <span>kein Stuhl</span>
+              <small>Negation · Maskulin</small>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section aria-labelledby="tips-heading">
+        <h2 id="tips-heading" data-i18n="tipsHeading">Merkt euch</h2>
+        <div class="tip-grid">
+          <article class="tip-card">
+            <h3>Plural-Endungen</h3>
+            <p>Viele Nomen bekommen -e, -er, -en oder -s.</p>
+          </article>
+          <article class="tip-card">
+            <h3>Artikel farbig merken</h3>
+            <p>Blau = maskulin, Rot = feminin, Grün = neutral.</p>
+          </article>
+          <article class="tip-card">
+            <h3>kein/keine im Plural</h3>
+            <p>Im Plural verwendest du immer „keine“.</p>
+          </article>
+        </div>
+      </section>
+
+      <section aria-labelledby="story-heading">
+        <h2 id="story-heading" data-i18n="storyHeading">Mini-Story</h2>
+        <div class="story-card">
+          <div class="story-line">
+            <span>1</span>
+            <p>Anna hat eine Wohnung. In der Küche steht ein Tisch.</p>
+          </div>
+          <div class="story-line">
+            <span>2</span>
+            <p>Sie hat zwei Stühle, aber keine Lampe.</p>
+          </div>
+          <div class="story-line">
+            <span>3</span>
+            <p>Ihr Freund bringt eine Lampe. Jetzt ist die Küche hell.</p>
+          </div>
+        </div>
+      </section>
+
+      <section aria-labelledby="practice-heading">
+        <h2 id="practice-heading" data-i18n="practiceHeading">Üben</h2>
+        <div class="practice-grid">
+          <article class="practice-card" data-practice="articles">
+            <h3 data-i18n="practice1Title">Wähle den richtigen Artikel</h3>
+            <p data-i18n="practice1Body">Tippe auf den passenden Artikel.</p>
+            <div class="example" id="article-word">___ Tisch</div>
+            <div class="chip-row" role="group" aria-label="Artikel Auswahl">
+              <button class="chip" data-answer="der">der</button>
+              <button class="chip" data-answer="die">die</button>
+              <button class="chip" data-answer="das">das</button>
+            </div>
+            <div class="progress" aria-hidden="true"><span id="article-progress"></span></div>
+          </article>
+
+          <article class="practice-card" data-practice="negation">
+            <h3 data-i18n="practice2Title">kein oder keine?</h3>
+            <p data-i18n="practice2Body">Wähle die richtige Negation.</p>
+            <div class="example" id="negation-word">___ Bücher</div>
+            <div class="chip-row" role="group" aria-label="Negation Auswahl">
+              <button class="chip" data-answer="kein">kein</button>
+              <button class="chip" data-answer="keine">keine</button>
+            </div>
+            <div class="progress" aria-hidden="true"><span id="negation-progress"></span></div>
+          </article>
+
+          <article class="practice-card" data-practice="plural">
+            <h3 data-i18n="practice3Title">Finde die Pluralform</h3>
+            <p data-i18n="practice3Body">Tippe auf die korrekte Form.</p>
+            <div class="example" id="plural-word">das Buch → ?</div>
+            <div class="chip-row" role="group" aria-label="Plural Auswahl">
+              <button class="chip" data-answer="Bücher">Bücher</button>
+              <button class="chip" data-answer="Buchen">Buchen</button>
+              <button class="chip" data-answer="Büchern">Büchern</button>
+            </div>
+            <div class="progress" aria-hidden="true"><span id="plural-progress"></span></div>
+          </article>
+        </div>
+      </section>
+
+      <footer data-i18n="footerNote">Tippe weiter – kleine Schritte bringen großen Fortschritt.</footer>
+    </main>
+
+    <button class="floating-action" id="refresh">
+      <span data-i18n="actionButton">Neue Runde</span>
+    </button>
+
+    <script>
+      const supportedLanguages = [
+        "en",
+        "ru",
+        "uk",
+        "es",
+        "fr",
+        "ar",
+        "tr",
+        "it",
+        "ro",
+        "sv",
+        "pt",
+        "ko",
+        "ja",
+        "nl",
+        "zh",
+        "hr",
+        "hy",
+      ];
+
+      const translations = {
+        en: {
+          title: "Nouns & Articles",
+          lessonTag: "A1 · Lesson 1",
+          description:
+            "Definite and indefinite articles, plural building, negation with ‘kein/keine’.",
+          badgeArticle: "Articles",
+          badgePlural: "Plurals",
+          badgeNegation: "kein/keine",
+          patternsHeading: "Key patterns",
+          tipsHeading: "Remember",
+          storyHeading: "Mini story",
+          practiceHeading: "Practice",
+          practice1Title: "Choose the right article",
+          practice1Body: "Tap the matching article.",
+          practice2Title: "kein or keine?",
+          practice2Body: "Pick the correct negation.",
+          practice3Title: "Find the plural",
+          practice3Body: "Tap the correct form.",
+          actionButton: "New round",
+          footerNote: "Keep tapping – tiny steps make big progress.",
+        },
+        ru: {
+          title: "Имена и артикли",
+          lessonTag: "A1 · Урок 1",
+          description:
+            "Определённые и неопределённые артикли, образование множественного, отрицание с «kein/keine».",
+          badgeArticle: "Артикли",
+          badgePlural: "Множественное",
+          badgeNegation: "kein/keine",
+          patternsHeading: "Главные модели",
+          tipsHeading: "Запомните",
+          storyHeading: "Мини-история",
+          practiceHeading: "Практика",
+          practice1Title: "Выберите правильный артикль",
+          practice1Body: "Нажмите нужный артикль.",
+          practice2Title: "kein или keine?",
+          practice2Body: "Выберите нужное отрицание.",
+          practice3Title: "Найдите множественное",
+          practice3Body: "Нажмите правильную форму.",
+          actionButton: "Новый раунд",
+          footerNote: "Маленькие шаги ведут к большому прогрессу.",
+        },
+        uk: {
+          title: "Іменники та артиклі",
+          lessonTag: "A1 · Урок 1",
+          description:
+            "Означені й неозначені артиклі, творення множини, заперечення з «kein/keine».",
+          badgeArticle: "Артиклі",
+          badgePlural: "Множина",
+          badgeNegation: "kein/keine",
+          patternsHeading: "Ключові моделі",
+          tipsHeading: "Запам'ятайте",
+          storyHeading: "Міні-історія",
+          practiceHeading: "Вправи",
+          practice1Title: "Обери правильний артикль",
+          practice1Body: "Натисни відповідний артикль.",
+          practice2Title: "kein чи keine?",
+          practice2Body: "Вибери правильне заперечення.",
+          practice3Title: "Знайди множину",
+          practice3Body: "Натисни правильну форму.",
+          actionButton: "Новий раунд",
+          footerNote: "Маленькі кроки дають великий результат.",
+        },
+        es: {
+          title: "Sustantivos y artículos",
+          lessonTag: "A1 · Lección 1",
+          description:
+            "Artículos determinados e indeterminados, plural, negación con «kein/keine».",
+          badgeArticle: "Artículos",
+          badgePlural: "Plural",
+          badgeNegation: "kein/keine",
+          patternsHeading: "Patrones clave",
+          tipsHeading: "Recuerda",
+          storyHeading: "Mini historia",
+          practiceHeading: "Practica",
+          practice1Title: "Elige el artículo correcto",
+          practice1Body: "Toca el artículo adecuado.",
+          practice2Title: "¿kein o keine?",
+          practice2Body: "Elige la negación correcta.",
+          practice3Title: "Encuentra el plural",
+          practice3Body: "Toca la forma correcta.",
+          actionButton: "Nueva ronda",
+          footerNote: "Pequeños pasos crean gran progreso.",
+        },
+        fr: {
+          title: "Noms et articles",
+          lessonTag: "A1 · Leçon 1",
+          description:
+            "Articles définis et indéfinis, pluriel, négation avec «kein/keine».",
+          badgeArticle: "Articles",
+          badgePlural: "Pluriel",
+          badgeNegation: "kein/keine",
+          patternsHeading: "Structures clés",
+          tipsHeading: "À retenir",
+          storyHeading: "Mini-histoire",
+          practiceHeading: "Entraîne-toi",
+          practice1Title: "Choisis le bon article",
+          practice1Body: "Tape sur l'article correct.",
+          practice2Title: "kein ou keine ?",
+          practice2Body: "Choisis la bonne négation.",
+          practice3Title: "Trouve le pluriel",
+          practice3Body: "Tape sur la bonne forme.",
+          actionButton: "Nouvelle série",
+          footerNote: "De petits pas mènent à un grand progrès.",
+        },
+        ar: {
+          title: "الأسماء وأدوات التعريف",
+          lessonTag: "A1 · الدرس 1",
+          description: "أداة التعريف والتنكير، الجمع، النفي باستخدام kein/keine.",
+          badgeArticle: "الأدوات",
+          badgePlural: "الجمع",
+          badgeNegation: "kein/keine",
+          patternsHeading: "أنماط أساسية",
+          tipsHeading: "تذكر",
+          storyHeading: "قصة قصيرة",
+          practiceHeading: "تدريب",
+          practice1Title: "اختر الأداة الصحيحة",
+          practice1Body: "اضغط الأداة المناسبة.",
+          practice2Title: "kein أم keine؟",
+          practice2Body: "اختر صيغة النفي الصحيحة.",
+          practice3Title: "اعثر على الجمع",
+          practice3Body: "اضغط الشكل الصحيح.",
+          actionButton: "جولة جديدة",
+          footerNote: "خطوات صغيرة تصنع تقدمًا كبيرًا.",
+        },
+        tr: {
+          title: "İsimler ve artikeller",
+          lessonTag: "A1 · Ders 1",
+          description: "Belirli-belirsiz artikeller, çoğul, ‘kein/keine’ ile olumsuzluk.",
+          badgeArticle: "Artikeller",
+          badgePlural: "Çoğul",
+          badgeNegation: "kein/keine",
+          patternsHeading: "Temel kalıplar",
+          tipsHeading: "Unutma",
+          storyHeading: "Mini hikâye",
+          practiceHeading: "Alıştırma",
+          practice1Title: "Doğru artikeli seç",
+          practice1Body: "Uygun artikeli dokun.",
+          practice2Title: "kein mi keine mi?",
+          practice2Body: "Doğru olumsuzluğu seç.",
+          practice3Title: "Çoğulu bul",
+          practice3Body: "Doğru biçime dokun.",
+          actionButton: "Yeni tur",
+          footerNote: "Küçük adımlar büyük ilerleme getirir.",
+        },
+        it: {
+          title: "Nomi e articoli",
+          lessonTag: "A1 · Lezione 1",
+          description: "Articoli determinativi e indeterminativi, plurale, negazione con «kein/keine».",
+          badgeArticle: "Articoli",
+          badgePlural: "Plurale",
+          badgeNegation: "kein/keine",
+          patternsHeading: "Schemi chiave",
+          tipsHeading: "Ricorda",
+          storyHeading: "Mini storia",
+          practiceHeading: "Esercizi",
+          practice1Title: "Scegli l'articolo giusto",
+          practice1Body: "Tocca l'articolo corretto.",
+          practice2Title: "kein o keine?",
+          practice2Body: "Scegli la negazione giusta.",
+          practice3Title: "Trova il plurale",
+          practice3Body: "Tocca la forma corretta.",
+          actionButton: "Nuovo giro",
+          footerNote: "Piccoli passi portano grande progresso.",
+        },
+        ro: {
+          title: "Substantive și articole",
+          lessonTag: "A1 · Lecția 1",
+          description: "Articole hotărâte și nehotărâte, plural, negație cu «kein/keine».",
+          badgeArticle: "Articole",
+          badgePlural: "Plural",
+          badgeNegation: "kein/keine",
+          patternsHeading: "Structuri cheie",
+          tipsHeading: "De reținut",
+          storyHeading: "Mini-poveste",
+          practiceHeading: "Exersează",
+          practice1Title: "Alege articolul corect",
+          practice1Body: "Atinge articolul potrivit.",
+          practice2Title: "kein sau keine?",
+          practice2Body: "Alege negația corectă.",
+          practice3Title: "Găsește pluralul",
+          practice3Body: "Atinge forma corectă.",
+          actionButton: "Rundă nouă",
+          footerNote: "Pașii mici aduc progres mare.",
+        },
+        sv: {
+          title: "Substantiv och artiklar",
+          lessonTag: "A1 · Lektion 1",
+          description: "Bestämda och obestämda artiklar, plural, negation med «kein/keine».",
+          badgeArticle: "Artiklar",
+          badgePlural: "Plural",
+          badgeNegation: "kein/keine",
+          patternsHeading: "Viktiga mönster",
+          tipsHeading: "Kom ihåg",
+          storyHeading: "Mini-berättelse",
+          practiceHeading: "Öva",
+          practice1Title: "Välj rätt artikel",
+          practice1Body: "Tryck på den rätta.",
+          practice2Title: "kein eller keine?",
+          practice2Body: "Välj rätt negation.",
+          practice3Title: "Hitta pluralen",
+          practice3Body: "Tryck på rätt form.",
+          actionButton: "Ny omgång",
+          footerNote: "Små steg ger stor utveckling.",
+        },
+        pt: {
+          title: "Substantivos e artigos",
+          lessonTag: "A1 · Lição 1",
+          description: "Artigos definidos e indefinidos, plural, negação com «kein/keine».",
+          badgeArticle: "Artigos",
+          badgePlural: "Plural",
+          badgeNegation: "kein/keine",
+          patternsHeading: "Padrões-chave",
+          tipsHeading: "Lembre-se",
+          storyHeading: "Mini-história",
+          practiceHeading: "Praticar",
+          practice1Title: "Escolha o artigo certo",
+          practice1Body: "Toque no artigo correto.",
+          practice2Title: "kein ou keine?",
+          practice2Body: "Escolha a negação certa.",
+          practice3Title: "Encontre o plural",
+          practice3Body: "Toque a forma correta.",
+          actionButton: "Nova rodada",
+          footerNote: "Pequenos passos geram grande progresso.",
+        },
+        ko: {
+          title: "명사와 관사",
+          lessonTag: "A1 · 1과",
+          description: "정관사·부정관사, 복수, kein/keine로 하는 부정.",
+          badgeArticle: "관사",
+          badgePlural: "복수",
+          badgeNegation: "kein/keine",
+          patternsHeading: "핵심 패턴",
+          tipsHeading: "기억해요",
+          storyHeading: "미니 스토리",
+          practiceHeading: "연습",
+          practice1Title: "맞는 관사를 고르세요",
+          practice1Body: "알맞은 관사를 누르세요.",
+          practice2Title: "kein? keine?",
+          practice2Body: "맞는 부정을 선택하세요.",
+          practice3Title: "복수형 찾기",
+          practice3Body: "올바른 형태를 누르세요.",
+          actionButton: "새 라운드",
+          footerNote: "작은 걸음이 큰 발전을 만듭니다.",
+        },
+        ja: {
+          title: "名詞と冠詞",
+          lessonTag: "A1 · レッスン1",
+          description: "定冠詞・不定冠詞、複数形、「kein/keine」での否定。",
+          badgeArticle: "冠詞",
+          badgePlural: "複数形",
+          badgeNegation: "kein/keine",
+          patternsHeading: "重要パターン",
+          tipsHeading: "覚えよう",
+          storyHeading: "ミニストーリー",
+          practiceHeading: "練習",
+          practice1Title: "正しい冠詞を選ぶ",
+          practice1Body: "合う冠詞をタップ。",
+          practice2Title: "kein それとも keine?",
+          practice2Body: "正しい否定を選ぶ。",
+          practice3Title: "複数形を探す",
+          practice3Body: "正しい形をタップ。",
+          actionButton: "新しいラウンド",
+          footerNote: "小さな一歩が大きな進歩につながる。",
+        },
+        nl: {
+          title: "Zelfstandige naamwoorden en lidwoorden",
+          lessonTag: "A1 · Les 1",
+          description: "Bepaalde en onbepaalde lidwoorden, meervoud, ontkenning met ‘kein/keine’.",
+          badgeArticle: "Lidwoorden",
+          badgePlural: "Meervoud",
+          badgeNegation: "kein/keine",
+          patternsHeading: "Belangrijke patronen",
+          tipsHeading: "Onthoud",
+          storyHeading: "Mini-verhaal",
+          practiceHeading: "Oefenen",
+          practice1Title: "Kies het juiste lidwoord",
+          practice1Body: "Tik op het juiste lidwoord.",
+          practice2Title: "kein of keine?",
+          practice2Body: "Kies de juiste ontkenning.",
+          practice3Title: "Vind het meervoud",
+          practice3Body: "Tik op de juiste vorm.",
+          actionButton: "Nieuwe ronde",
+          footerNote: "Kleine stappen zorgen voor grote vooruitgang.",
+        },
+        zh: {
+          title: "名词与冠词",
+          lessonTag: "A1 · 第1课",
+          description: "定冠词、不定冠词、复数形式以及“kein/keine”否定。",
+          badgeArticle: "冠词",
+          badgePlural: "复数",
+          badgeNegation: "kein/keine",
+          patternsHeading: "关键模式",
+          tipsHeading: "记住",
+          storyHeading: "迷你故事",
+          practiceHeading: "练习",
+          practice1Title: "选择正确的冠词",
+          practice1Body: "点击合适的冠词。",
+          practice2Title: "kein 还是 keine?",
+          practice2Body: "选择正确的否定。",
+          practice3Title: "找出复数",
+          practice3Body: "点击正确形式。",
+          actionButton: "重新开始",
+          footerNote: "一步一步，稳步提升。",
+        },
+        hr: {
+          title: "Imenice i članci",
+          lessonTag: "A1 · Lekcija 1",
+          description: "Određeni i neodređeni članci, množina, nijekanje s ‘kein/keine’.",
+          badgeArticle: "Članci",
+          badgePlural: "Množina",
+          badgeNegation: "kein/keine",
+          patternsHeading: "Ključni obrasci",
+          tipsHeading: "Zapamti",
+          storyHeading: "Mini priča",
+          practiceHeading: "Vježbaj",
+          practice1Title: "Odaberi točan član",
+          practice1Body: "Dodirni odgovarajući član.",
+          practice2Title: "kein ili keine?",
+          practice2Body: "Odaberi pravilnu negaciju.",
+          practice3Title: "Pronađi množinu",
+          practice3Body: "Dodirni točan oblik.",
+          actionButton: "Nova runda",
+          footerNote: "Mali koraci vode velikom napretku.",
+        },
+        hy: {
+          title: "Գոյականներ և հոդեր",
+          lessonTag: "A1 · Դաս 1",
+          description: "Սահմանված ու անորոշ հոդեր, բազմական, ժխտում «kein/keine»-ով։",
+          badgeArticle: "Հոդեր",
+          badgePlural: "Բազմական",
+          badgeNegation: "kein/keine",
+          patternsHeading: "Կարևոր ձևեր",
+          tipsHeading: "Հիշեք",
+          storyHeading: "Մինի պատմություն",
+          practiceHeading: "Վարժանք",
+          practice1Title: "Ընտրեք ճիշտ հոդը",
+          practice1Body: "Սեղմեք համապատասխան հոդի վրա։",
+          practice2Title: "kein թե keine?",
+          practice2Body: "Ընտրեք ճիշտ ժխտումը։",
+          practice3Title: "Գտեք բազմականը",
+          practice3Body: "Սեղմեք ճիշտ ձևը։",
+          actionButton: "Նոր փուլ",
+          footerNote: "Փոքր քայլերը բերում են մեծ առաջընթաց։",
+        },
+      };
+
+      const articleExercises = [
+        { word: "___ Tisch", correct: "der" },
+        { word: "___ Lampe", correct: "die" },
+        { word: "___ Buch", correct: "das" },
+        { word: "___ Stuhl", correct: "der" },
+        { word: "___ Wohnung", correct: "die" },
+      ];
+
+      const negationExercises = [
+        { word: "___ Bücher", correct: "keine" },
+        { word: "___ Brot", correct: "kein" },
+        { word: "___ Kinder", correct: "keine" },
+        { word: "___ Wasser", correct: "kein" },
+      ];
+
+      const pluralExercises = [
+        { word: "der Tisch", correct: "Tische", options: ["Tische", "Tischer", "Tischn"] },
+        { word: "die Lampe", correct: "Lampen", options: ["Lampen", "Lamper", "Lampe"] },
+        { word: "das Buch", correct: "Bücher", options: ["Bücher", "Buchs", "Büchern"] },
+        { word: "der Apfel", correct: "Äpfel", options: ["Äpfel", "Apfels", "Apfeln"] },
+      ];
+
+      const sample = (items) => items[Math.floor(Math.random() * items.length)];
+
+      const setProgress = (element, value) => {
+        requestAnimationFrame(() => {
+          element.style.width = `${value}%`;
+        });
+      };
+
+      const updateExercise = (config) => {
+        const {
+          wordElement,
+          chips,
+          progress,
+          generator,
+        } = config;
+        const exercise = generator();
+        wordElement.textContent = config.prefix ? `${config.prefix} ${exercise.word}` : exercise.word;
+        chips.forEach((chip, index) => {
+          chip.classList.remove("selected", "correct", "incorrect");
+          chip.disabled = false;
+          if (exercise.options) {
+            chip.textContent = exercise.options[index];
+            chip.dataset.answer = exercise.options[index];
+          }
+        });
+        config.current = exercise;
+        setProgress(progress, 0);
+      };
+
+      const attachLogic = () => {
+        const articleWord = document.getElementById("article-word");
+        const articleChips = Array.from(
+          document.querySelectorAll('[data-practice="articles"] .chip')
+        );
+        const articleProgress = document.getElementById("article-progress");
+
+        const negationWord = document.getElementById("negation-word");
+        const negationChips = Array.from(
+          document.querySelectorAll('[data-practice="negation"] .chip')
+        );
+        const negationProgress = document.getElementById("negation-progress");
+
+        const pluralWord = document.getElementById("plural-word");
+        const pluralChips = Array.from(
+          document.querySelectorAll('[data-practice="plural"] .chip')
+        );
+        const pluralProgress = document.getElementById("plural-progress");
+
+        const setups = [
+          {
+            chips: articleChips,
+            wordElement: articleWord,
+            progress: articleProgress,
+            generator: () => sample(articleExercises),
+          },
+          {
+            chips: negationChips,
+            wordElement: negationWord,
+            progress: negationProgress,
+            generator: () => sample(negationExercises),
+          },
+          {
+            chips: pluralChips,
+            wordElement: pluralWord,
+            progress: pluralProgress,
+            generator: () => {
+              const exercise = sample(pluralExercises);
+              const shuffled = [...exercise.options].sort(() => Math.random() - 0.5);
+              return { ...exercise, options: shuffled };
+            },
+          },
+        ];
+
+        setups.forEach((setup) => updateExercise(setup));
+
+        setups.forEach((setup) => {
+          setup.chips.forEach((chip) => {
+            chip.addEventListener("click", () => {
+              if (chip.disabled) return;
+              setup.chips.forEach((c) => c.classList.remove("selected"));
+              chip.classList.add("selected");
+              const answer = chip.dataset.answer || chip.textContent;
+              const isCorrect = answer.trim() === setup.current.correct;
+              chip.classList.add(isCorrect ? "correct" : "incorrect");
+              setup.chips.forEach((c) => (c.disabled = true));
+              setProgress(setup.progress, isCorrect ? 100 : 40);
+              setTimeout(() => updateExercise(setup), 1400);
+            });
+          });
+        });
+
+        document.getElementById("refresh").addEventListener("click", () => {
+          setups.forEach((setup) => updateExercise(setup));
+        });
+      };
+
+      const applyLanguage = () => {
+        const params = new URLSearchParams(window.location.search);
+        const lang = params.get("lang");
+        const activeLang = supportedLanguages.includes(lang) ? lang : "en";
+        document.documentElement.lang = activeLang;
+        const messages = translations[activeLang] || translations.en;
+
+        document.querySelectorAll("[data-i18n]").forEach((element) => {
+          const key = element.dataset.i18n;
+          if (messages[key]) {
+            element.textContent = messages[key];
+          }
+        });
+
+        const badgeArticle = document.querySelector('[data-i18n="badgeArticle"]');
+        badgeArticle && (badgeArticle.lastChild.textContent = ` ${messages.badgeArticle || "Artikel"}`);
+        const badgePlural = document.querySelector('[data-i18n="badgePlural"]');
+        badgePlural && (badgePlural.lastChild.textContent = ` ${messages.badgePlural || "Plural"}`);
+        const badgeNegation = document.querySelector('[data-i18n="badgeNegation"]');
+        badgeNegation && (badgeNegation.lastChild.textContent = ` ${messages.badgeNegation || "kein/keine"}`);
+      };
+
+      applyLanguage();
+      attachLogic();
+    </script>
+  </body>
+</html>

--- a/Lingo/Lingo_Structure
+++ b/Lingo/Lingo_Structure
@@ -4,109 +4,425 @@
       "id": "A1",
       "title": "Anfänger (A1)",
       "chapters": [
-        { "id": "A1-1", "title": "Nomen und Artikel", "description": "Bestimmte/Unbestimmte Artikel, Pluralbildung, Verneinung mit ‚kein/keine‘." },
-        { "id": "A1-2", "title": "Pronomen", "description": "Personal-, Possessiv- und Reflexivpronomen im Grundgebrauch." },
-        { "id": "A1-3", "title": "Verbkonjugation", "description": "Regelmäßige/Unregelmäßige Verben, Modalverben, trennbare Verben, ‚sein‘/‚haben‘, Imperativ." },
-        { "id": "A1-4", "title": "Satzbau", "description": "Aussagesätze, Ja/Nein-Fragen, W-Fragen, Negation, ‚es gibt‘." },
-        { "id": "A1-5", "title": "Zahlen, Daten und Uhrzeit", "description": "Zahlen bis 100, Wochentage, Monate/Jahreszeiten, Uhrzeit, Datum/Kalender." },
-        { "id": "A1-6", "title": "Kasus (Fälle)", "description": "Nominativ, Akkusativ, Einführung in den Dativ mit häufigen Verben/Präpositionen." },
-        { "id": "A1-7", "title": "Negation", "description": "Negation mit ‚nicht‘ und ‚kein/keine‘; negative Aussagen im Alltag." },
-        { "id": "A1-8", "title": "Präpositionen", "description": "Lokale, temporale und Wechselpräpositionen (Akk./Dat.)." },
-        { "id": "A1-9", "title": "Adjektive", "description": "Adjektive ohne/mit Deklination, Komparativ und Superlativ (Grundlagen)." },
-        { "id": "A1-10", "title": "Alltagsvokabeln", "description": "Farben; Familie; Hobbys; Essen/Trinken; Berufe; Wohnung/Möbel; Kleidung; Wetter; Reisen/Verkehr." },
-        { "id": "A1-11", "title": "Dialoge und Leseverständnis", "description": "Begrüßung; Einkaufen; unterwegs; Arzt; Restaurant; zu Hause; Telefon; Stadt; Freizeit; Büro; Einladungen; Gefühle; Orientierung." },
-        { "id": "A1-12", "title": "Prüfungsvorbereitung A1", "description": "Hören, Lesen, Schreiben (Kurztexte), Sprechen (Vorstellen, Fragen, einfache Dialoge)." }
+        {
+          "id": "A1-1",
+          "title": "Nomen und Artikel",
+          "description": "Bestimmte/Unbestimmte Artikel, Pluralbildung, Verneinung mit ‚kein/keine‘."
+        },
+        {
+          "id": "A1-2",
+          "title": "Pronomen",
+          "description": "Personal-, Possessiv- und Reflexivpronomen im Grundgebrauch."
+        },
+        {
+          "id": "A1-3",
+          "title": "Verbkonjugation",
+          "description": "Regelmäßige/Unregelmäßige Verben, Modalverben, trennbare Verben, ‚sein‘/‚haben‘, Imperativ."
+        },
+        {
+          "id": "A1-4",
+          "title": "Satzbau",
+          "description": "Aussagesätze, Ja/Nein-Fragen, W-Fragen, Negation, ‚es gibt‘."
+        },
+        {
+          "id": "A1-5",
+          "title": "Zahlen, Daten und Uhrzeit",
+          "description": "Zahlen bis 100, Wochentage, Monate/Jahreszeiten, Uhrzeit, Datum/Kalender."
+        },
+        {
+          "id": "A1-6",
+          "title": "Kasus (Fälle)",
+          "description": "Nominativ, Akkusativ, Einführung in den Dativ mit häufigen Verben/Präpositionen."
+        },
+        {
+          "id": "A1-7",
+          "title": "Negation",
+          "description": "Negation mit ‚nicht‘ und ‚kein/keine‘; negative Aussagen im Alltag."
+        },
+        {
+          "id": "A1-8",
+          "title": "Präpositionen",
+          "description": "Lokale, temporale und Wechselpräpositionen (Akk./Dat.)."
+        },
+        {
+          "id": "A1-9",
+          "title": "Adjektive",
+          "description": "Adjektive ohne/mit Deklination, Komparativ und Superlativ (Grundlagen)."
+        },
+        {
+          "id": "A1-10",
+          "title": "Alltagsvokabeln",
+          "description": "Farben; Familie; Hobbys; Essen/Trinken; Berufe; Wohnung/Möbel; Kleidung; Wetter; Reisen/Verkehr."
+        },
+        {
+          "id": "A1-11",
+          "title": "Dialoge und Leseverständnis",
+          "description": "Begrüßung; Einkaufen; unterwegs; Arzt; Restaurant; zu Hause; Telefon; Stadt; Freizeit; Büro; Einladungen; Gefühle; Orientierung."
+        },
+        {
+          "id": "A1-12",
+          "title": "Prüfungsvorbereitung A1",
+          "description": "Hören, Lesen, Schreiben (Kurztexte), Sprechen (Vorstellen, Fragen, einfache Dialoge)."
+        }
       ]
     },
     {
       "id": "A2",
       "title": "Grundlegende Kenntnisse (A2)",
       "chapters": [
-        { "id": "A2-1", "title": "Wiederholung A1 gezielt", "description": "Festigung von Artikeln, Grundverben, Basiswortschatz und Satzbau." },
-        { "id": "A2-2", "title": "Zeiten: Präsens & Perfekt", "description": "Perfektbildung mit ‚haben/sein‘; Partizip II häufiger Verben; Erzählung in der Vergangenheit." },
-        { "id": "A2-3", "title": "Präteritum der Modalverben", "description": "Kontrast Präsens/Präteritum von können, müssen, wollen, dürfen, sollen, mögen." },
-        { "id": "A2-4", "title": "Dativ vertiefen", "description": "Dativobjekte; Dativpräpositionen (mit, nach, bei, seit, von, zu, aus, außer, gegenüber)." },
-        { "id": "A2-5", "title": "Akkusativ vs. Dativ mit Wechselpräpositionen", "description": "Wechsel zwischen Lage und Richtung (in, an, auf, über, unter, vor, hinter, neben, zwischen)." },
-        { "id": "A2-6", "title": "Trennbare & untrennbare Verben", "description": "Bedeutungsunterschiede, Betonung, Perfektbildung." },
-        { "id": "A2-7", "title": "Adjektivendungen im A2-Umfang", "description": "Starke/schwache/gemischte Deklination in häufigen Mustern." },
-        { "id": "A2-8", "title": "Nebensätze: weil, dass, wenn", "description": "Verbendstellung; Konnektoren für Begründung, indirekte Aussagen und Bedingungen." },
-        { "id": "A2-9", "title": "Relativsätze im Nominativ/Akkusativ", "description": "Relativpronomen der/die/das; einfache Einbettung zur Beschreibung." },
-        { "id": "A2-10", "title": "Trends im Wortschatz Alltag", "description": "Gesundheit, Wohnen, Reisen, Arbeit, Schule, Medien, Einkaufen (A2-Umfang)." },
-        { "id": "A2-11", "title": "Höflichkeit & Formen", "description": "Höfliche Bitten, Vorschläge, Einladungen; Konjunktiv II von ‚mögen‘/‚würde‘-Formen." },
-        { "id": "A2-12", "title": "Vergleiche & Steigerung", "description": "Komparativ/Superlativ in typischen Sprechsituationen." },
-        { "id": "A2-13", "title": "Zeitangaben & Temporalsätze", "description": "vor/nach, seit/bis; als/wenn; Reihenfolgen erzählen." },
-        { "id": "A2-14", "title": "Präpositionen der Richtung", "description": "Wegbeschreibungen, Orientierung in der Stadt, Verkehrsmittel nutzen." },
-        { "id": "A2-15", "title": "Formulare & E-Mails", "description": "Einfach formell schreiben: Anfrage, Beschwerde, Bewerbungsskizze." },
-        { "id": "A2-16", "title": "Telefonieren & Termine", "description": "Nachfragen, bestätigen, verschieben; Redemittel am Telefon." },
-        { "id": "A2-17", "title": "Medien & Technik", "description": "Einfache Anleitungen verstehen; Online-Services nutzen; Sicherheitshinweise." },
-        { "id": "A2-18", "title": "Kultur & Freizeit planen", "description": "Einladungen, gemeinsame Pläne, Wetter & Kleidung, Ticketkauf." },
-        { "id": "A2-19", "title": "Fehlerquellen A2", "description": "Satzklammer, Verbzweit/Endstellung, Artikelwahl, Kasus bei Präpositionen." },
-        { "id": "A2-20", "title": "Prüfungsvorbereitung A2", "description": "Aufgabenformate Hören/Lesen/Schreiben/Sprechen mit Strategien." }
+        {
+          "id": "A2-1",
+          "title": "Wiederholung A1 gezielt",
+          "description": "Festigung von Artikeln, Grundverben, Basiswortschatz und Satzbau."
+        },
+        {
+          "id": "A2-2",
+          "title": "Zeiten: Präsens & Perfekt",
+          "description": "Perfektbildung mit ‚haben/sein‘; Partizip II häufiger Verben; Erzählung in der Vergangenheit."
+        },
+        {
+          "id": "A2-3",
+          "title": "Präteritum der Modalverben",
+          "description": "Kontrast Präsens/Präteritum von können, müssen, wollen, dürfen, sollen, mögen."
+        },
+        {
+          "id": "A2-4",
+          "title": "Dativ vertiefen",
+          "description": "Dativobjekte; Dativpräpositionen (mit, nach, bei, seit, von, zu, aus, außer, gegenüber)."
+        },
+        {
+          "id": "A2-5",
+          "title": "Akkusativ vs. Dativ mit Wechselpräpositionen",
+          "description": "Wechsel zwischen Lage und Richtung (in, an, auf, über, unter, vor, hinter, neben, zwischen)."
+        },
+        {
+          "id": "A2-6",
+          "title": "Trennbare & untrennbare Verben",
+          "description": "Bedeutungsunterschiede, Betonung, Perfektbildung."
+        },
+        {
+          "id": "A2-7",
+          "title": "Adjektivendungen im A2-Umfang",
+          "description": "Starke/schwache/gemischte Deklination in häufigen Mustern."
+        },
+        {
+          "id": "A2-8",
+          "title": "Nebensätze: weil, dass, wenn",
+          "description": "Verbendstellung; Konnektoren für Begründung, indirekte Aussagen und Bedingungen."
+        },
+        {
+          "id": "A2-9",
+          "title": "Relativsätze im Nominativ/Akkusativ",
+          "description": "Relativpronomen der/die/das; einfache Einbettung zur Beschreibung."
+        },
+        {
+          "id": "A2-10",
+          "title": "Trends im Wortschatz Alltag",
+          "description": "Gesundheit, Wohnen, Reisen, Arbeit, Schule, Medien, Einkaufen (A2-Umfang)."
+        },
+        {
+          "id": "A2-11",
+          "title": "Höflichkeit & Formen",
+          "description": "Höfliche Bitten, Vorschläge, Einladungen; Konjunktiv II von ‚mögen‘/‚würde‘-Formen."
+        },
+        {
+          "id": "A2-12",
+          "title": "Vergleiche & Steigerung",
+          "description": "Komparativ/Superlativ in typischen Sprechsituationen."
+        },
+        {
+          "id": "A2-13",
+          "title": "Zeitangaben & Temporalsätze",
+          "description": "vor/nach, seit/bis; als/wenn; Reihenfolgen erzählen."
+        },
+        {
+          "id": "A2-14",
+          "title": "Präpositionen der Richtung",
+          "description": "Wegbeschreibungen, Orientierung in der Stadt, Verkehrsmittel nutzen."
+        },
+        {
+          "id": "A2-15",
+          "title": "Formulare & E-Mails",
+          "description": "Einfach formell schreiben: Anfrage, Beschwerde, Bewerbungsskizze."
+        },
+        {
+          "id": "A2-16",
+          "title": "Telefonieren & Termine",
+          "description": "Nachfragen, bestätigen, verschieben; Redemittel am Telefon."
+        },
+        {
+          "id": "A2-17",
+          "title": "Medien & Technik",
+          "description": "Einfache Anleitungen verstehen; Online-Services nutzen; Sicherheitshinweise."
+        },
+        {
+          "id": "A2-18",
+          "title": "Kultur & Freizeit planen",
+          "description": "Einladungen, gemeinsame Pläne, Wetter & Kleidung, Ticketkauf."
+        },
+        {
+          "id": "A2-19",
+          "title": "Fehlerquellen A2",
+          "description": "Satzklammer, Verbzweit/Endstellung, Artikelwahl, Kasus bei Präpositionen."
+        },
+        {
+          "id": "A2-20",
+          "title": "Prüfungsvorbereitung A2",
+          "description": "Aufgabenformate Hören/Lesen/Schreiben/Sprechen mit Strategien."
+        }
       ]
     },
     {
       "id": "B1",
       "title": "Selbstständige Sprachverwendung (B1)",
       "chapters": [
-        { "id": "B1-1", "title": "Zeiten im Überblick", "description": "Präsens, Perfekt, Präteritum, Plusquamperfekt – Erzählen über Vergangenheit." },
-        { "id": "B1-2", "title": "Futur I & Pläne", "description": "Vermutungen, Absichten und Vorhersagen ausdrücken." },
-        { "id": "B1-3", "title": "Konjunktiv II: Wünsche & Höflichkeit", "description": "würde-Formen; könnten/möchten; irreale Bedingungen im Ansatz." },
-        { "id": "B1-4", "title": "Passiv (werden/sein)", "description": "Prozess- und Zustandspassiv in Alltagstexten." },
-        { "id": "B1-5", "title": "Erweiterte Nebensätze", "description": "obwohl, damit, sodass, während; Verbendstellung sicher anwenden." },
-        { "id": "B1-6", "title": "Relativsätze alle Fälle", "description": "Nominativ, Akkusativ, Dativ, Genitiv; Kommasetzung." },
-        { "id": "B1-7", "title": "Nominalisierung & Komposita", "description": "Substantivierung, zusammengesetzte Nomen verstehen/bilden." },
-        { "id": "B1-8", "title": "Adjektivdeklination sicher", "description": "Systematisches Training in allen Fällen mit/ohne Artikel." },
-        { "id": "B1-9", "title": "Wortschatz Arbeit & Ausbildung", "description": "Bewerbung, Lebenslauf, Stellenanzeigen, Arbeitsalltag." },
-        { "id": "B1-10", "title": "Gesellschaft & Alltag", "description": "Behörden, Versicherungen, Wohnen, Umwelt, Konsum." },
-        { "id": "B1-11", "title": "Argumentieren & Meinung", "description": "Pro/Contra, Begründungen, Zustimmen/Widersprechen." },
-        { "id": "B1-12", "title": "Grafiken & Zahlen beschreiben", "description": "Trends, Vergleiche, Prozentangaben sprachlich umsetzen." },
-        { "id": "B1-13", "title": "Strategien Lesen/Hören", "description": "Selektives Lesen, Globalverstehen, Hörstrategien im Alltag." },
-        { "id": "B1-14", "title": "Schreiben B1", "description": "Formelle/halboffizielle E-Mails, Berichte, Beschwerden." },
-        { "id": "B1-15", "title": "Sprechen B1", "description": "Spontan reagieren, zusammenhängend erzählen, Erfahrungen schildern." },
-        { "id": "B1-16", "title": "Redemittel Präsentation", "description": "Vortrag strukturieren, Überleitungen, Schluss formulieren." },
-        { "id": "B1-17", "title": "Typische Fehler B1", "description": "Kasus nach Verben/Präpositionen, Wortstellung, Passivfallen." },
-        { "id": "B1-18", "title": "Prüfungsvorbereitung B1", "description": "Formatkenntnis, Zeitmanagement, Musterprüfungen." }
+        {
+          "id": "B1-1",
+          "title": "Zeiten im Überblick",
+          "description": "Präsens, Perfekt, Präteritum, Plusquamperfekt – Erzählen über Vergangenheit."
+        },
+        {
+          "id": "B1-2",
+          "title": "Futur I & Pläne",
+          "description": "Vermutungen, Absichten und Vorhersagen ausdrücken."
+        },
+        {
+          "id": "B1-3",
+          "title": "Konjunktiv II: Wünsche & Höflichkeit",
+          "description": "würde-Formen; könnten/möchten; irreale Bedingungen im Ansatz."
+        },
+        {
+          "id": "B1-4",
+          "title": "Passiv (werden/sein)",
+          "description": "Prozess- und Zustandspassiv in Alltagstexten."
+        },
+        {
+          "id": "B1-5",
+          "title": "Erweiterte Nebensätze",
+          "description": "obwohl, damit, sodass, während; Verbendstellung sicher anwenden."
+        },
+        {
+          "id": "B1-6",
+          "title": "Relativsätze alle Fälle",
+          "description": "Nominativ, Akkusativ, Dativ, Genitiv; Kommasetzung."
+        },
+        {
+          "id": "B1-7",
+          "title": "Nominalisierung & Komposita",
+          "description": "Substantivierung, zusammengesetzte Nomen verstehen/bilden."
+        },
+        {
+          "id": "B1-8",
+          "title": "Adjektivdeklination sicher",
+          "description": "Systematisches Training in allen Fällen mit/ohne Artikel."
+        },
+        {
+          "id": "B1-9",
+          "title": "Wortschatz Arbeit & Ausbildung",
+          "description": "Bewerbung, Lebenslauf, Stellenanzeigen, Arbeitsalltag."
+        },
+        {
+          "id": "B1-10",
+          "title": "Gesellschaft & Alltag",
+          "description": "Behörden, Versicherungen, Wohnen, Umwelt, Konsum."
+        },
+        {
+          "id": "B1-11",
+          "title": "Argumentieren & Meinung",
+          "description": "Pro/Contra, Begründungen, Zustimmen/Widersprechen."
+        },
+        {
+          "id": "B1-12",
+          "title": "Grafiken & Zahlen beschreiben",
+          "description": "Trends, Vergleiche, Prozentangaben sprachlich umsetzen."
+        },
+        {
+          "id": "B1-13",
+          "title": "Strategien Lesen/Hören",
+          "description": "Selektives Lesen, Globalverstehen, Hörstrategien im Alltag."
+        },
+        {
+          "id": "B1-14",
+          "title": "Schreiben B1",
+          "description": "Formelle/halboffizielle E-Mails, Berichte, Beschwerden."
+        },
+        {
+          "id": "B1-15",
+          "title": "Sprechen B1",
+          "description": "Spontan reagieren, zusammenhängend erzählen, Erfahrungen schildern."
+        },
+        {
+          "id": "B1-16",
+          "title": "Redemittel Präsentation",
+          "description": "Vortrag strukturieren, Überleitungen, Schluss formulieren."
+        },
+        {
+          "id": "B1-17",
+          "title": "Typische Fehler B1",
+          "description": "Kasus nach Verben/Präpositionen, Wortstellung, Passivfallen."
+        },
+        {
+          "id": "B1-18",
+          "title": "Prüfungsvorbereitung B1",
+          "description": "Formatkenntnis, Zeitmanagement, Musterprüfungen."
+        }
       ]
     },
     {
       "id": "B2",
       "title": "Fortgeschrittene Sprachverwendung (B2)",
       "chapters": [
-        { "id": "B2-1", "title": "Satzkomplexität & Konnektoren", "description": "Kausale, konzessive, konsekutive, finale, modale Verknüpfungen." },
-        { "id": "B2-2", "title": "Verbvalenz & Rektion", "description": "Verben mit festen Präpositionen; Bedeutungsunterschiede." },
-        { "id": "B2-3", "title": "Passivvarianten & Alternativen", "description": "Man-Form, lassen, sich-Passiv; stilistische Wahl." },
-        { "id": "B2-4", "title": "Konjunktiv I & indirekte Rede", "description": "Berichten, Distanz markieren, Quellenangaben." },
-        { "id": "B2-5", "title": "Nominalstil & Verdichtung", "description": "Dichte Fachtexte verstehen/produzieren, Präpositionalgruppen." },
-        { "id": "B2-6", "title": "Wortbildung B2", "description": "Präfixe/Suffixe, Bedeutungsnuancen, Wortfamilien." },
-        { "id": "B2-7", "title": "Stil & Register", "description": "Formell vs. informell, höflich vs. direkt, textsortengerecht." },
-        { "id": "B2-8", "title": "Diskutieren & Verhandeln", "description": "Nuanciert zustimmen/ablehnen, Vorschläge aushandeln." },
-        { "id": "B2-9", "title": "Akademischer Wortschatz", "description": "Definitionen, Beispiele, Ursache-Wirkung, Vergleich/Übertragung." },
-        { "id": "B2-10", "title": "Berufskommunikation", "description": "Meetings, Berichte, E-Mail-Etikette, Feedback geben." },
-        { "id": "B2-11", "title": "Diagramme & Studien", "description": "Daten präzise interpretieren und präsentieren." },
-        { "id": "B2-12", "title": "Kohärenz & Kohäsion", "description": "Themenentfaltung, Rückbezüge, Absatzlogik." },
-        { "id": "B2-13", "title": "Aussprachefeinheiten", "description": "Wortakzent, Satzmelodie, Reduktionen im schnellen Sprechen." },
-        { "id": "B2-14", "title": "Fehleranalyse B2", "description": "Feinheiten bei Kasus/Artikel, Verbzweit, Mehrfachnebensätze." },
-        { "id": "B2-15", "title": "Prüfungsvorbereitung B2", "description": "Aufgabentypen, Strategien, simulierte Prüfungen." }
+        {
+          "id": "B2-1",
+          "title": "Satzkomplexität & Konnektoren",
+          "description": "Kausale, konzessive, konsekutive, finale, modale Verknüpfungen."
+        },
+        {
+          "id": "B2-2",
+          "title": "Verbvalenz & Rektion",
+          "description": "Verben mit festen Präpositionen; Bedeutungsunterschiede."
+        },
+        {
+          "id": "B2-3",
+          "title": "Passivvarianten & Alternativen",
+          "description": "Man-Form, lassen, sich-Passiv; stilistische Wahl."
+        },
+        {
+          "id": "B2-4",
+          "title": "Konjunktiv I & indirekte Rede",
+          "description": "Berichten, Distanz markieren, Quellenangaben."
+        },
+        {
+          "id": "B2-5",
+          "title": "Nominalstil & Verdichtung",
+          "description": "Dichte Fachtexte verstehen/produzieren, Präpositionalgruppen."
+        },
+        {
+          "id": "B2-6",
+          "title": "Wortbildung B2",
+          "description": "Präfixe/Suffixe, Bedeutungsnuancen, Wortfamilien."
+        },
+        {
+          "id": "B2-7",
+          "title": "Stil & Register",
+          "description": "Formell vs. informell, höflich vs. direkt, textsortengerecht."
+        },
+        {
+          "id": "B2-8",
+          "title": "Diskutieren & Verhandeln",
+          "description": "Nuanciert zustimmen/ablehnen, Vorschläge aushandeln."
+        },
+        {
+          "id": "B2-9",
+          "title": "Akademischer Wortschatz",
+          "description": "Definitionen, Beispiele, Ursache-Wirkung, Vergleich/Übertragung."
+        },
+        {
+          "id": "B2-10",
+          "title": "Berufskommunikation",
+          "description": "Meetings, Berichte, E-Mail-Etikette, Feedback geben."
+        },
+        {
+          "id": "B2-11",
+          "title": "Diagramme & Studien",
+          "description": "Daten präzise interpretieren und präsentieren."
+        },
+        {
+          "id": "B2-12",
+          "title": "Kohärenz & Kohäsion",
+          "description": "Themenentfaltung, Rückbezüge, Absatzlogik."
+        },
+        {
+          "id": "B2-13",
+          "title": "Aussprachefeinheiten",
+          "description": "Wortakzent, Satzmelodie, Reduktionen im schnellen Sprechen."
+        },
+        {
+          "id": "B2-14",
+          "title": "Fehleranalyse B2",
+          "description": "Feinheiten bei Kasus/Artikel, Verbzweit, Mehrfachnebensätze."
+        },
+        {
+          "id": "B2-15",
+          "title": "Prüfungsvorbereitung B2",
+          "description": "Aufgabentypen, Strategien, simulierte Prüfungen."
+        }
       ]
     },
     {
       "id": "C1",
       "title": "Fortgeschrittene Kenntnisse (C1)",
       "chapters": [
-        { "id": "C1-1", "title": "Stilsicherheit & Nuancen", "description": "Ironie, Implikaturen, idiomatische Wendungen sicher verstehen/anwenden." },
-        { "id": "C1-2", "title": "Komplexe Syntax", "description": "Mehrfach eingebettete Nebensätze, Partizipial-/Infinitivkonstruktionen." },
-        { "id": "C1-3", "title": "Konjunktiv & Distanzierung", "description": "Konjunktiv I/II differenziert; Hedges, Vorsichtsformulierungen." },
-        { "id": "C1-4", "title": "Argumentation auf hohem Niveau", "description": "Thesen entwickeln, Gegenargumente antizipieren, Evidenz bewerten." },
-        { "id": "C1-5", "title": "Wissenschaftliche Textsorten", "description": "Abstract, Einleitung, Diskussion, Fazit; Zitierweisen." },
-        { "id": "C1-6", "title": "Fachsprache & Registerwechsel", "description": "Domänenspezifischer Wortschatz, präzise Terminologie, Registeranpassung." },
-        { "id": "C1-7", "title": "Diskurs & Rhetorik", "description": "Redestrategien, Metadiskurs, rhetorische Figuren." },
-        { "id": "C1-8", "title": "Feinsinnige Kohäsion", "description": "Anaphern, Ellipsen, Substitution, Thema-Rhema-Progression." },
-        { "id": "C1-9", "title": "Stilistische Überarbeitung", "description": "Redundanz vermeiden, Präzision steigern, Textökonomie." },
-        { "id": "C1-10", "title": "Interkulturelle Pragmatik", "description": "Höflichkeitsnormen, indirekte Sprechakte, Smalltalk vs. Fachgespräch." },
-        { "id": "C1-11", "title": "Hören/Lesen auf C1", "description": "Schnelles Erfassen komplexer Vorträge und längerer Fachtexte." },
-        { "id": "C1-12", "title": "Schreiben C1", "description": "Kohärente, gut strukturierte Essays/Reports mit starker Argumentationslinie." },
-        { "id": "C1-13", "title": "Sprechen C1", "description": "Flüssige, nuancierte Beiträge, spontane Präzisierung und Selbstkorrektur." },
-        { "id": "C1-14", "title": "Prüfungsvorbereitung C1", "description": "Aufgabenanalyse, Zeitplanung, Prüfungsrhetorik, Probe-Performances." }
+        {
+          "id": "C1-1",
+          "title": "Stilsicherheit & Nuancen",
+          "description": "Ironie, Implikaturen, idiomatische Wendungen sicher verstehen/anwenden."
+        },
+        {
+          "id": "C1-2",
+          "title": "Komplexe Syntax",
+          "description": "Mehrfach eingebettete Nebensätze, Partizipial-/Infinitivkonstruktionen."
+        },
+        {
+          "id": "C1-3",
+          "title": "Konjunktiv & Distanzierung",
+          "description": "Konjunktiv I/II differenziert; Hedges, Vorsichtsformulierungen."
+        },
+        {
+          "id": "C1-4",
+          "title": "Argumentation auf hohem Niveau",
+          "description": "Thesen entwickeln, Gegenargumente antizipieren, Evidenz bewerten."
+        },
+        {
+          "id": "C1-5",
+          "title": "Wissenschaftliche Textsorten",
+          "description": "Abstract, Einleitung, Diskussion, Fazit; Zitierweisen."
+        },
+        {
+          "id": "C1-6",
+          "title": "Fachsprache & Registerwechsel",
+          "description": "Domänenspezifischer Wortschatz, präzise Terminologie, Registeranpassung."
+        },
+        {
+          "id": "C1-7",
+          "title": "Diskurs & Rhetorik",
+          "description": "Redestrategien, Metadiskurs, rhetorische Figuren."
+        },
+        {
+          "id": "C1-8",
+          "title": "Feinsinnige Kohäsion",
+          "description": "Anaphern, Ellipsen, Substitution, Thema-Rhema-Progression."
+        },
+        {
+          "id": "C1-9",
+          "title": "Stilistische Überarbeitung",
+          "description": "Redundanz vermeiden, Präzision steigern, Textökonomie."
+        },
+        {
+          "id": "C1-10",
+          "title": "Interkulturelle Pragmatik",
+          "description": "Höflichkeitsnormen, indirekte Sprechakte, Smalltalk vs. Fachgespräch."
+        },
+        {
+          "id": "C1-11",
+          "title": "Hören/Lesen auf C1",
+          "description": "Schnelles Erfassen komplexer Vorträge und längerer Fachtexte."
+        },
+        {
+          "id": "C1-12",
+          "title": "Schreiben C1",
+          "description": "Kohärente, gut strukturierte Essays/Reports mit starker Argumentationslinie."
+        },
+        {
+          "id": "C1-13",
+          "title": "Sprechen C1",
+          "description": "Flüssige, nuancierte Beiträge, spontane Präzisierung und Selbstkorrektur."
+        },
+        {
+          "id": "C1-14",
+          "title": "Prüfungsvorbereitung C1",
+          "description": "Aufgabenanalyse, Zeitplanung, Prüfungsrhetorik, Probe-Performances."
+        }
       ]
     }
   ]

--- a/index.js
+++ b/index.js
@@ -49,6 +49,10 @@ app.get("/", (req, res) => {
   res.sendFile(path.join(__dirname, "static", "index.html"));
 })
 
+app.get("/lingo/a1-1", (req, res) => {
+  res.sendFile(path.join(__dirname, "Lingo", "A1-1.html"));
+});
+
 app.get("/privacy-policy", (req, res) => {
   res.sendFile(path.join(__dirname, "static", "privacy-policy.html"));
 })

--- a/router/LingoApi.js
+++ b/router/LingoApi.js
@@ -1,0 +1,105 @@
+const express = require("express");
+const fs = require("fs");
+const path = require("path");
+
+const lingoRouter = express.Router();
+const structurePath = path.join(__dirname, "..", "Lingo", "Lingo_Structure");
+
+const CHAPTER_URLS = {
+  "A1-1": "/lingo/a1-1",
+};
+
+const SUPPORTED_LANGUAGES = new Set([
+  "en",
+  "ru",
+  "uk",
+  "es",
+  "fr",
+  "ar",
+  "tr",
+  "it",
+  "ro",
+  "sv",
+  "pt",
+  "ko",
+  "ja",
+  "nl",
+  "zh",
+  "hr",
+  "hy",
+]);
+
+const pickLanguage = (ln) => {
+  if (!ln || typeof ln !== "string") {
+    return { error: "Query parameter 'ln' is required." };
+  }
+
+  const normalized = ln.toLowerCase();
+  if (!SUPPORTED_LANGUAGES.has(normalized)) {
+    return {
+      error: `Unsupported language code '${ln}'.`,
+      supported: Array.from(SUPPORTED_LANGUAGES).sort(),
+    };
+  }
+
+  return { language: normalized };
+};
+
+const readStructure = () => {
+  const fileContent = fs.readFileSync(structurePath, "utf-8");
+  return JSON.parse(fileContent);
+};
+
+const withChapterUrls = (structure) => ({
+  ...structure,
+  levels: (structure.levels || []).map((level) => ({
+    ...level,
+    chapters: (level.chapters || []).map((chapter) => ({
+      ...chapter,
+      ...(CHAPTER_URLS[chapter.id] ? { url: CHAPTER_URLS[chapter.id] } : {}),
+    })),
+  })),
+});
+
+lingoRouter.get("/structure", (req, res) => {
+  const { ln } = req.query;
+  const { error, supported, language } = pickLanguage(ln);
+  if (error) {
+    return res.status(400).json({ message: error, supportedLanguages: supported });
+  }
+
+  try {
+    const structure = withChapterUrls(readStructure());
+    res.json({ ...structure, language });
+  } catch (error) {
+    res.status(500).json({ message: error.message || "Unable to load structure" });
+  }
+});
+
+lingoRouter.get("/chapters/:chapterId", (req, res) => {
+  const { ln } = req.query;
+  const { error, supported, language } = pickLanguage(ln);
+  if (error) {
+    return res.status(400).json({ message: error, supportedLanguages: supported });
+  }
+
+  try {
+    const { chapterId } = req.params;
+    const structure = withChapterUrls(readStructure());
+    for (const level of structure.levels || []) {
+      const chapter = (level.chapters || []).find(({ id }) => id === chapterId);
+      if (chapter) {
+        return res.json({
+          language,
+          level: { id: level.id, title: level.title },
+          chapter,
+        });
+      }
+    }
+    res.status(404).json({ message: "Chapter not found" });
+  } catch (error) {
+    res.status(500).json({ message: error.message || "Unable to load chapter" });
+  }
+});
+
+module.exports = lingoRouter;

--- a/router/apiRouter.js
+++ b/router/apiRouter.js
@@ -6,6 +6,7 @@ const appApi = require("./appApi");
 const feedRouter = require("./feedRouter");
 const germanWikiRouter = require("./germanWiki");
 const horoscopeRouter = require("./horoscopeRouter");
+const lingoRouter = require("./LingoApi");
 const { readUsersJson, userError } = require("../helper");
 
 const apiRoutes = express.Router();
@@ -16,6 +17,7 @@ apiRoutes.use("/app", appApi);
 apiRoutes.use("/feed", feedRouter);
 apiRoutes.use('/german-wiki', germanWikiRouter);
 apiRoutes.use('/horoscope', horoscopeRouter);
+apiRoutes.use('/lingo', lingoRouter);
 
 
 apiRoutes.get("/healthcheck", (req, res) => res.sendStatus(200));


### PR DESCRIPTION
## Summary
- remove hardcoded lesson URLs from the `Lingo_Structure` JSON definition
- add a chapter-to-URL map in the Lingo API and inject URLs into responses dynamically

## Testing
- node -e "require('./router/LingoApi'); console.log('LingoApi loaded');"

------
https://chatgpt.com/codex/tasks/task_e_68cd3e47a8448328a582a65de1c35275