### PR TITLE
Remove lesson parameter from Lingo chapter URLs

### DIFF
--- a/router/LingoApi.js
+++ b/router/LingoApi.js
@@ -59,9 +59,6 @@ const buildChapterUrl = (chapterId, language) => {
   if (language) {
     url.searchParams.set("ln", language);
   }
-  if (chapterId) {
-    url.searchParams.set("lesson", chapterId);
-  }
   return url.toString();
 };
 


### PR DESCRIPTION
## Summary
- update the Lingo chapter URL builder to omit the redundant lesson query parameter
- keep language query parameter support unchanged

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd6730e478832898f27556c4531de2