### PR TITLE
Fix Lingo lesson pages loading without styles

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,8 @@ app.get("/", (req, res) => {
 const lingoDirectory = path.join(__dirname, "Lingo");
 const comingSoonPage = path.join(lingoDirectory, "lesson-coming-soon.html");
 
+app.use("/lingo", express.static(lingoDirectory));
+
 app.get("/lingo/:lessonId", (req, res) => {
   const { lessonId } = req.params;
   const normalizedId = String(lessonId || "")


### PR DESCRIPTION
## Summary
- serve the `Lingo` directory through Express so lesson assets like stylesheets resolve correctly
- leave the existing fallback route intact so unknown lessons still show the "coming soon" page

## Testing
- node index.js
- curl -I http://127.0.0.1:8000/lingo/styles.css

------
https://chatgpt.com/codex/tasks/task_e_68cd83d64bcc83289e0ea6d8d78cec6b