### PR TITLE
Move Lingo API into Lingo directory

### DIFF
--- a/Lingo/LingoApi.js
+++ b/Lingo/LingoApi.js
@@ -3,7 +3,7 @@ const fs = require("fs");
 const path = require("path");
 
 const lingoRouter = express.Router();
-const structurePath = path.join(__dirname, "..", "Lingo", "Lingo_Structure");
+const structurePath = path.join(__dirname, "Lingo_Structure");
 
 const BASE_URL = "https://thegeneralapps.com";
 

--- a/router/apiRouter.js
+++ b/router/apiRouter.js
@@ -6,7 +6,7 @@ const appApi = require("./appApi");
 const feedRouter = require("./feedRouter");
 const germanWikiRouter = require("./germanWiki");
 const horoscopeRouter = require("./horoscopeRouter");
-const lingoRouter = require("./LingoApi");
+const lingoRouter = require("../Lingo/LingoApi");
 const { readUsersJson, userError } = require("../helper");
 
 const apiRoutes = express.Router();


### PR DESCRIPTION
## Summary
- relocate the Lingo API router into the Lingo directory
- update the API router to import the Lingo module from its new location
- adjust the structure file path inside the Lingo API module for its new directory

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cfce0994988328934631c4a306c2f8