### PR TITLE
Add dedicated styling and refreshed lesson page for Lingo A1-1

### DIFF
--- a/Lingo/A1-1.html
+++ b/Lingo/A1-1.html
@@ -1,666 +1,302 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="de">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
-    <title>Nomen &amp; Artikel · A1</title>
-    <link rel="stylesheet" href="./styles.css" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>A1 · Bestimmte Artikel im Singular</title>
+    <meta
+      name="description"
+      content="Lerne, wie du der, die und das sicher im Alltag nutzt – mit Beispielen, Farbcode und kurzen Übungen."
+    />
+    <link rel="stylesheet" href="./Lingo_styles.css" />
   </head>
   <body>
-    <main class="app" aria-live="polite">
+    <main class="app-shell">
       <header class="hero">
-        <span class="lesson-chip" data-i18n="lessonTag">A1 · Lektion 1</span>
-        <h1 data-i18n="title">Nomen &amp; Artikel</h1>
-        <p data-i18n="description">
-          Bestimmte/Unbestimmte Artikel, Pluralbildung, Verneinung mit „kein/keine“.
-        </p>
-        <div class="badge-row">
-          <span class="badge" data-i18n="badgeArticle">
-            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 4c-.55 0-1 .45-1 1v14c0 .55.45 1 1 1h12c.55 0 1-.45 1-1V5c0-.55-.45-1-1-1H6zm6 3.5 3.5 6h-7l3.5-6z"/></svg>
-            Artikel
-          </span>
-          <span class="badge" data-i18n="badgePlural">
-            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3 2 9l10 6 10-6-10-6zm0 9.09L5.47 9 12 4.91 18.53 9 12 12.09zM2 15l10 6 10-6-2.53-1.52L12 18.09 4.53 13.48 2 15z"/></svg>
-            Plural
-          </span>
-          <span class="badge" data-i18n="badgeNegation">
-            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2a10 10 0 1 0 10 10A10.011 10.011 0 0 0 12 2Zm0 4a6 6 0 0 1 3.46 1.09L7.09 15.46A6 6 0 0 1 12 6Zm0 12a6 6 0 0 1-3.46-1.09l8.37-8.37A6 6 0 0 1 12 18Z"/></svg>
-            kein/keine
-          </span>
+        <div class="hero-content">
+          <span class="level-chip">A1 · Kapitel 1</span>
+          <h1>Bestimmte Artikel im Singular</h1>
+          <p>
+            Verwende der, die und das bei häufigen Nomen sicher, damit jeder sofort versteht,
+            worüber du sprichst.
+          </p>
+          <ul class="hero-highlights">
+            <li>
+              <span>Ziel</span>
+              Automatisch zum richtigen Artikel greifen, wenn du neue Nomen sagst.
+            </li>
+            <li>
+              <span>Strategie</span>
+              Nutze Endungen, Bedeutungsgruppen und Merksätze als Anker.
+            </li>
+            <li>
+              <span>Praxis</span>
+              Wiederhole täglich mit Mini-Übungen und höre genau hin.
+            </li>
+          </ul>
+        </div>
+        <div class="hero-visual" aria-hidden="true">
+          <h2>Artikel-Farben</h2>
+          <div class="gender-row">
+            <div><span class="color-pill" data-gender="m">der</span><small>maskulin</small></div>
+            <div><span class="color-pill" data-gender="f">die</span><small>feminin</small></div>
+            <div><span class="color-pill" data-gender="n">das</span><small>neutral</small></div>
+          </div>
         </div>
       </header>
 
-      <section aria-labelledby="patterns-heading">
-        <h2 id="patterns-heading" data-i18n="patternsHeading">Schlüsselstrukturen</h2>
-        <div class="pattern-grid">
-          <article class="pattern-card">
-            <h3>der / die / das + Nomen</h3>
+      <section class="section" id="overview">
+        <div class="section-header">
+          <h2 class="section-title">Warum die bestimmten Artikel wichtig sind</h2>
+          <p class="section-subtitle">
+            Deutsche Nomen brauchen fast immer einen Artikel – er zeigt Genus (grammatisches
+            Geschlecht) und hilft deinem Gegenüber, das richtige Bild im Kopf zu haben.
+          </p>
+        </div>
+        <div class="card-grid">
+          <article class="card">
+            <h3>Kernidee</h3>
             <p>
-              Verwende den bestimmten Artikel, wenn alle wissen, wovon du sprichst.
+              Der bestimmte Artikel (der/die/das) verweist auf etwas Konkretes, das bereits bekannt
+              oder eindeutig ist.
             </p>
-            <div class="example">
-              <span>der Tisch</span>
-              <small>Maskulin · Singular</small>
-            </div>
+            <div class="example-bubble"><span>der Kaffee</span><small>ein konkreter Kaffee</small></div>
           </article>
-          <article class="pattern-card">
-            <h3>ein / eine + Nomen</h3>
+          <article class="card">
+            <h3>Struktur</h3>
             <p>
-              Verwende den unbestimmten Artikel für etwas Neues oder Unbekanntes.
+              Artikel stehen direkt vor dem Nomen. Beide bilden zusammen den Kern der Nominalphrase.
             </p>
-            <div class="example">
-              <span>eine Lampe</span>
-              <small>Feminin · Singular</small>
-            </div>
+            <div class="example-bubble"><span>die Lampe</span><small>Artikel + Nomen</small></div>
           </article>
-          <article class="pattern-card">
-            <h3>kein / keine + Nomen</h3>
+          <article class="card">
+            <h3>Fehler vermeiden</h3>
             <p>
-              „kein“ ersetzt den Artikel in negativen Aussagen und stimmt in Genus und Numerus.
+              Ein falscher Artikel fällt sofort auf. Wiederhole häufige Nomen mit dem passenden
+              Artikel als Chunk.
             </p>
-            <div class="example">
-              <span>kein Stuhl</span>
-              <small>Negation · Maskulin</small>
-            </div>
+            <div class="example-bubble"><span>das Fenster</span><small>Neutral · Singular</small></div>
           </article>
         </div>
       </section>
 
-      <section aria-labelledby="tips-heading">
-        <h2 id="tips-heading" data-i18n="tipsHeading">Merkt euch</h2>
-        <div class="tip-grid">
-          <article class="tip-card">
-            <h3>Plural-Endungen</h3>
-            <p>Viele Nomen bekommen -e, -er, -en oder -s.</p>
+      <section class="section" id="patterns">
+        <div class="section-header">
+          <h2 class="section-title">Schlüsselstrukturen</h2>
+          <p class="section-subtitle">So kombinierst du die bestimmten Artikel sicher.</p>
+        </div>
+        <div class="card-grid">
+          <article class="card">
+            <h3>der + maskulines Nomen</h3>
+            <p>
+              Viele Berufe, Wochentage und Nomen mit den Endungen -er, -en, -el sind maskulin.
+            </p>
+            <div class="example-bubble"><span>der Lehrer</span><small>Beruf · maskulin</small></div>
           </article>
-          <article class="tip-card">
-            <h3>Artikel farbig merken</h3>
-            <p>Blau = maskulin, Rot = feminin, Grün = neutral.</p>
+          <article class="card">
+            <h3>die + feminines Nomen</h3>
+            <p>
+              Nomen, die auf -e, -heit, -keit, -ung enden, sind oft feminin. Auch viele Personenrollen.
+            </p>
+            <div class="example-bubble"><span>die Blume</span><small>Endung -e</small></div>
           </article>
-          <article class="tip-card">
-            <h3>kein/keine im Plural</h3>
-            <p>Im Plural verwendest du immer „keine“.</p>
+          <article class="card">
+            <h3>das + neutrales Nomen</h3>
+            <p>
+              Wörter mit Ge- + -e/-er, Verkleinerungen (-chen, -lein) und die meisten Infinitive als
+              Nomen sind neutral.
+            </p>
+            <div class="example-bubble"><span>das Mädchen</span><small>Endung -chen</small></div>
           </article>
         </div>
       </section>
 
-      <section aria-labelledby="story-heading">
-        <h2 id="story-heading" data-i18n="storyHeading">Mini-Story</h2>
-        <div class="story-card">
-          <div class="story-line">
+      <section class="section" id="color-code">
+        <div class="section-header">
+          <h2 class="section-title">Visualisiere mit Farben</h2>
+          <p class="section-subtitle">
+            Verbinde jeden Artikel mit einer Farbe, um ihn schneller im Gedächtnis zu verankern.
+          </p>
+        </div>
+        <div class="color-legend">
+          <article class="color-card">
+            <div class="color-pill" data-gender="m">der</div>
+            <p>Blau erinnert an Maskulina: der Stuhl, der Morgen, der Salat.</p>
+          </article>
+          <article class="color-card">
+            <div class="color-pill" data-gender="f">die</div>
+            <p>Rot für Feminina: die Uhr, die Lehrerin, die Meinung.</p>
+          </article>
+          <article class="color-card">
+            <div class="color-pill" data-gender="n">das</div>
+            <p>Grün für Neutra: das Haus, das Gespräch, das Wasser.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="section" id="mini-story">
+        <div class="section-header">
+          <h2 class="section-title">Mini-Story: Artikel im Alltag</h2>
+          <p class="section-subtitle">Lies laut mit und achte auf die farblichen Artikel.</p>
+        </div>
+        <div class="timeline">
+          <div class="timeline-step">
             <span>1</span>
-            <p>Anna hat eine Wohnung. In der Küche steht ein Tisch.</p>
+            <p>Am Morgen deckt Lara <strong>den</strong> Tisch. <strong>Der</strong> Kaffee duftet schon.</p>
           </div>
-          <div class="story-line">
+          <div class="timeline-step">
             <span>2</span>
-            <p>Sie hat zwei Stühle, aber keine Lampe.</p>
+            <p>
+              Im Wohnzimmer schaltet sie <strong>die</strong> Lampe an und öffnet <strong>das</strong>
+              Fenster.
+            </p>
           </div>
-          <div class="story-line">
+          <div class="timeline-step">
             <span>3</span>
-            <p>Ihr Freund bringt eine Lampe. Jetzt ist die Küche hell.</p>
+            <p>
+              Später ruft <strong>der</strong> Freund an. <strong>Die</strong> Einladung zum Konzert liegt
+              auf <strong>dem</strong> Tisch.
+            </p>
           </div>
         </div>
       </section>
 
-      <section aria-labelledby="practice-heading">
-        <h2 id="practice-heading" data-i18n="practiceHeading">Üben</h2>
-        <div class="practice-grid">
-          <article class="practice-card" data-practice="articles">
-            <h3 data-i18n="practice1Title">Wähle den richtigen Artikel</h3>
-            <p data-i18n="practice1Body">Tippe auf den passenden Artikel.</p>
-            <div class="example" id="article-word">___ Tisch</div>
-            <div class="chip-row" role="group" aria-label="Artikel Auswahl">
-              <button class="chip" data-answer="der">der</button>
-              <button class="chip" data-answer="die">die</button>
-              <button class="chip" data-answer="das">das</button>
-            </div>
-            <div class="progress" aria-hidden="true"><span id="article-progress"></span></div>
+      <section class="section" id="practice">
+        <div class="section-header">
+          <h2 class="section-title">Üben &amp; festigen</h2>
+          <p class="section-subtitle">
+            Tippe auf den passenden Artikel. Nach einer richtigen Antwort geht es automatisch weiter.
+          </p>
+        </div>
+        <div class="practice-lab">
+          <article
+            class="practice-card"
+            data-items='[
+              {"prompt":"___ Tisch","options":["der","die","das"],"answer":"der","feedback":"Tisch ist maskulin – merke dir den Tisch.","hint":"Endungen wie -ich oder Möbelstücke helfen: der Tisch."},
+              {"prompt":"___ Lampe","options":["der","die","das"],"answer":"die","feedback":"Viele Wörter auf -e sind feminin: die Lampe.","hint":"Schau auf die Endung -e – sie ist oft ein Signal für die."},
+              {"prompt":"___ Fenster","options":["der","die","das"],"answer":"das","feedback":"Fenster ist neutral – stell dir das Fenster mit grünem Rahmen vor.","hint":"Dinge mit Gehäuse oder auf -er sind häufig neutral."}
+            ]'
+          >
+            <h3>Welche Form passt?</h3>
+            <p>Wähle den richtigen Artikel für das Nomen.</p>
+            <div class="practice-prompt" data-role="prompt"></div>
+            <div class="option-group" data-role="options" role="group" aria-label="Artikel auswählen"></div>
+            <div class="practice-feedback" data-role="feedback" aria-live="polite"></div>
           </article>
 
-          <article class="practice-card" data-practice="negation">
-            <h3 data-i18n="practice2Title">kein oder keine?</h3>
-            <p data-i18n="practice2Body">Wähle die richtige Negation.</p>
-            <div class="example" id="negation-word">___ Bücher</div>
-            <div class="chip-row" role="group" aria-label="Negation Auswahl">
-              <button class="chip" data-answer="kein">kein</button>
-              <button class="chip" data-answer="keine">keine</button>
-            </div>
-            <div class="progress" aria-hidden="true"><span id="negation-progress"></span></div>
+          <article
+            class="practice-card"
+            data-items='[
+              {"prompt":"___ Lehrer erklärt den Test.","options":["Der","Die","Das"],"answer":"Der","feedback":"Berufe sind fast immer maskulin: der Lehrer.","hint":"Berufsbezeichnungen ohne Endung bleiben meist maskulin."},
+              {"prompt":"___ Zeitung liegt auf dem Sofa.","options":["Der","Die","Das"],"answer":"Die","feedback":"Zeitung endet auf -ung – typisch feminin.","hint":"Endung -ung? Dann wähle die."},
+              {"prompt":"___ Museum öffnet um zehn Uhr.","options":["Der","Die","Das"],"answer":"Das","feedback":"Viele auf -um sind neutral: das Museum.","hint":"Lateinische Lehnwörter auf -um sind fast immer das."}
+            ]'
+          >
+            <h3>Setze den Artikel ein</h3>
+            <p>Großschreibung hilft dir, die Struktur zu sehen.</p>
+            <div class="practice-prompt" data-role="prompt"></div>
+            <div class="option-group" data-role="options" role="group" aria-label="Satzartikel auswählen"></div>
+            <div class="practice-feedback" data-role="feedback" aria-live="polite"></div>
           </article>
 
-          <article class="practice-card" data-practice="plural">
-            <h3 data-i18n="practice3Title">Finde die Pluralform</h3>
-            <p data-i18n="practice3Body">Tippe auf die korrekte Form.</p>
-            <div class="example" id="plural-word">das Buch → ?</div>
-            <div class="chip-row" role="group" aria-label="Plural Auswahl">
-              <button class="chip" data-answer="Bücher">Bücher</button>
-              <button class="chip" data-answer="Buchen">Buchen</button>
-              <button class="chip" data-answer="Büchern">Büchern</button>
-            </div>
-            <div class="progress" aria-hidden="true"><span id="plural-progress"></span></div>
+          <article
+            class="practice-card"
+            data-items='[
+              {"prompt":"Welche Verbindung ist korrekt?","options":["der Mann ist freundlich","die Mann ist freundlich","das Mann ist freundlich"],"answer":"der Mann ist freundlich","feedback":"Maskulin + maskulines Nomen: der Mann.","hint":"Überlege: Wer? der Mann – männliche Personen."},
+              {"prompt":"Welche Verbindung ist korrekt?","options":["die Idee ist neu","der Idee ist neu","das Idee ist neu"],"answer":"die Idee ist neu","feedback":"Idee endet auf -e – feminin.","hint":"Endung -e weist auf die Idee hin."},
+              {"prompt":"Welche Verbindung ist korrekt?","options":["das Auto ist schnell","der Auto ist schnell","die Auto ist schnell"],"answer":"das Auto ist schnell","feedback":"Technische Geräte sind oft neutral.","hint":"Geräte und Dinge – häufig das."}
+            ]'
+          >
+            <h3>Artikel + Adjektiv</h3>
+            <p>Wähle die Kombination, die im Deutschen funktioniert.</p>
+            <div class="practice-prompt" data-role="prompt"></div>
+            <div class="option-group" data-role="options" role="group" aria-label="Richtige Kombination auswählen"></div>
+            <div class="practice-feedback" data-role="feedback" aria-live="polite"></div>
           </article>
         </div>
       </section>
 
-      <footer data-i18n="footerNote">Tippe weiter – kleine Schritte bringen großen Fortschritt.</footer>
+      <section class="section" id="reference">
+        <div class="section-header">
+          <h2 class="section-title">Schnelle Referenz</h2>
+          <p class="section-subtitle">Speichere dir die wichtigsten Merksätze.</p>
+        </div>
+        <div class="quick-reference">
+          <article class="reference-card">
+            <h4>Maskulin? Oft ja bei …</h4>
+            <ul>
+              <li>Berufe und Personen in der männlichen Form</li>
+              <li>Wochentage, Monate, Jahreszeiten</li>
+              <li>Endungen: -er, -en, -el</li>
+            </ul>
+          </article>
+          <article class="reference-card">
+            <h4>Feminin? Typisch sind …</h4>
+            <ul>
+              <li>Endungen: -e, -heit, -keit, -schaft, -ung</li>
+              <li>Viele Pflanzen und Blumen</li>
+              <li>Die meisten Zahlen (die Eins, die Zwei …)</li>
+            </ul>
+          </article>
+          <article class="reference-card">
+            <h4>Neutral? Merke dir …</h4>
+            <ul>
+              <li>Ge- + -e/-er (das Gemüse, das Gebäude)</li>
+              <li>Verkleinerungen: -chen, -lein</li>
+              <li>Farben, Metalle und Verben als Nomen</li>
+            </ul>
+          </article>
+        </div>
+      </section>
+
+      <p class="footer-note">Bleib dran – kleine Wiederholungen sichern den Artikel dauerhaft.</p>
     </main>
 
-    <button class="floating-action" id="refresh">
-      <span data-i18n="actionButton">Neue Runde</span>
-    </button>
-
     <script>
-      const supportedLanguages = [
-        "en",
-        "ru",
-        "uk",
-        "es",
-        "fr",
-        "ar",
-        "tr",
-        "it",
-        "ro",
-        "sv",
-        "pt",
-        "ko",
-        "ja",
-        "nl",
-        "zh",
-        "hr",
-        "hy",
-      ];
+      document.querySelectorAll(".practice-card").forEach((card) => {
+        const promptEl = card.querySelector('[data-role="prompt"]');
+        const optionsEl = card.querySelector('[data-role="options"]');
+        const feedbackEl = card.querySelector('[data-role="feedback"]');
+        const items = JSON.parse(card.dataset.items || "[]");
+        let index = 0;
+        let lock = false;
 
-      const translations = {
-        en: {
-          title: "Nouns & Articles",
-          lessonTag: "A1 · Lesson 1",
-          description:
-            "Definite and indefinite articles, plural building, negation with ‘kein/keine’.",
-          badgeArticle: "Articles",
-          badgePlural: "Plurals",
-          badgeNegation: "kein/keine",
-          patternsHeading: "Key patterns",
-          tipsHeading: "Remember",
-          storyHeading: "Mini story",
-          practiceHeading: "Practice",
-          practice1Title: "Choose the right article",
-          practice1Body: "Tap the matching article.",
-          practice2Title: "kein or keine?",
-          practice2Body: "Pick the correct negation.",
-          practice3Title: "Find the plural",
-          practice3Body: "Tap the correct form.",
-          actionButton: "New round",
-          footerNote: "Keep tapping – tiny steps make big progress.",
-        },
-        ru: {
-          title: "Имена и артикли",
-          lessonTag: "A1 · Урок 1",
-          description:
-            "Определённые и неопределённые артикли, образование множественного, отрицание с «kein/keine».",
-          badgeArticle: "Артикли",
-          badgePlural: "Множественное",
-          badgeNegation: "kein/keine",
-          patternsHeading: "Главные модели",
-          tipsHeading: "Запомните",
-          storyHeading: "Мини-история",
-          practiceHeading: "Практика",
-          practice1Title: "Выберите правильный артикль",
-          practice1Body: "Нажмите нужный артикль.",
-          practice2Title: "kein или keine?",
-          practice2Body: "Выберите нужное отрицание.",
-          practice3Title: "Найдите множественное",
-          practice3Body: "Нажмите правильную форму.",
-          actionButton: "Новый раунд",
-          footerNote: "Маленькие шаги ведут к большому прогрессу.",
-        },
-        uk: {
-          title: "Іменники та артиклі",
-          lessonTag: "A1 · Урок 1",
-          description:
-            "Означені й неозначені артиклі, творення множини, заперечення з «kein/keine».",
-          badgeArticle: "Артиклі",
-          badgePlural: "Множина",
-          badgeNegation: "kein/keine",
-          patternsHeading: "Ключові моделі",
-          tipsHeading: "Запам'ятайте",
-          storyHeading: "Міні-історія",
-          practiceHeading: "Вправи",
-          practice1Title: "Обери правильний артикль",
-          practice1Body: "Натисни відповідний артикль.",
-          practice2Title: "kein чи keine?",
-          practice2Body: "Вибери правильне заперечення.",
-          practice3Title: "Знайди множину",
-          practice3Body: "Натисни правильну форму.",
-          actionButton: "Новий раунд",
-          footerNote: "Маленькі кроки дають великий результат.",
-        },
-        es: {
-          title: "Sustantivos y artículos",
-          lessonTag: "A1 · Lección 1",
-          description:
-            "Artículos determinados e indeterminados, plural, negación con «kein/keine».",
-          badgeArticle: "Artículos",
-          badgePlural: "Plural",
-          badgeNegation: "kein/keine",
-          patternsHeading: "Patrones clave",
-          tipsHeading: "Recuerda",
-          storyHeading: "Mini historia",
-          practiceHeading: "Practica",
-          practice1Title: "Elige el artículo correcto",
-          practice1Body: "Toca el artículo adecuado.",
-          practice2Title: "¿kein o keine?",
-          practice2Body: "Elige la negación correcta.",
-          practice3Title: "Encuentra el plural",
-          practice3Body: "Toca la forma correcta.",
-          actionButton: "Nueva ronda",
-          footerNote: "Pequeños pasos crean gran progreso.",
-        },
-        fr: {
-          title: "Noms et articles",
-          lessonTag: "A1 · Leçon 1",
-          description:
-            "Articles définis et indéfinis, pluriel, négation avec «kein/keine».",
-          badgeArticle: "Articles",
-          badgePlural: "Pluriel",
-          badgeNegation: "kein/keine",
-          patternsHeading: "Structures clés",
-          tipsHeading: "À retenir",
-          storyHeading: "Mini-histoire",
-          practiceHeading: "Entraîne-toi",
-          practice1Title: "Choisis le bon article",
-          practice1Body: "Tape sur l'article correct.",
-          practice2Title: "kein ou keine ?",
-          practice2Body: "Choisis la bonne négation.",
-          practice3Title: "Trouve le pluriel",
-          practice3Body: "Tape sur la bonne forme.",
-          actionButton: "Nouvelle série",
-          footerNote: "De petits pas mènent à un grand progrès.",
-        },
-        ar: {
-          title: "الأسماء وأدوات التعريف",
-          lessonTag: "A1 · الدرس 1",
-          description: "أداة التعريف والتنكير، الجمع، النفي باستخدام kein/keine.",
-          badgeArticle: "الأدوات",
-          badgePlural: "الجمع",
-          badgeNegation: "kein/keine",
-          patternsHeading: "أنماط أساسية",
-          tipsHeading: "تذكر",
-          storyHeading: "قصة قصيرة",
-          practiceHeading: "تدريب",
-          practice1Title: "اختر الأداة الصحيحة",
-          practice1Body: "اضغط الأداة المناسبة.",
-          practice2Title: "kein أم keine؟",
-          practice2Body: "اختر صيغة النفي الصحيحة.",
-          practice3Title: "اعثر على الجمع",
-          practice3Body: "اضغط الشكل الصحيح.",
-          actionButton: "جولة جديدة",
-          footerNote: "خطوات صغيرة تصنع تقدمًا كبيرًا.",
-        },
-        tr: {
-          title: "İsimler ve artikeller",
-          lessonTag: "A1 · Ders 1",
-          description: "Belirli-belirsiz artikeller, çoğul, ‘kein/keine’ ile olumsuzluk.",
-          badgeArticle: "Artikeller",
-          badgePlural: "Çoğul",
-          badgeNegation: "kein/keine",
-          patternsHeading: "Temel kalıplar",
-          tipsHeading: "Unutma",
-          storyHeading: "Mini hikâye",
-          practiceHeading: "Alıştırma",
-          practice1Title: "Doğru artikeli seç",
-          practice1Body: "Uygun artikeli dokun.",
-          practice2Title: "kein mi keine mi?",
-          practice2Body: "Doğru olumsuzluğu seç.",
-          practice3Title: "Çoğulu bul",
-          practice3Body: "Doğru biçime dokun.",
-          actionButton: "Yeni tur",
-          footerNote: "Küçük adımlar büyük ilerleme getirir.",
-        },
-        it: {
-          title: "Nomi e articoli",
-          lessonTag: "A1 · Lezione 1",
-          description: "Articoli determinativi e indeterminativi, plurale, negazione con «kein/keine».",
-          badgeArticle: "Articoli",
-          badgePlural: "Plurale",
-          badgeNegation: "kein/keine",
-          patternsHeading: "Schemi chiave",
-          tipsHeading: "Ricorda",
-          storyHeading: "Mini storia",
-          practiceHeading: "Esercizi",
-          practice1Title: "Scegli l'articolo giusto",
-          practice1Body: "Tocca l'articolo corretto.",
-          practice2Title: "kein o keine?",
-          practice2Body: "Scegli la negazione giusta.",
-          practice3Title: "Trova il plurale",
-          practice3Body: "Tocca la forma corretta.",
-          actionButton: "Nuovo giro",
-          footerNote: "Piccoli passi portano grande progresso.",
-        },
-        ro: {
-          title: "Substantive și articole",
-          lessonTag: "A1 · Lecția 1",
-          description: "Articole hotărâte și nehotărâte, plural, negație cu «kein/keine».",
-          badgeArticle: "Articole",
-          badgePlural: "Plural",
-          badgeNegation: "kein/keine",
-          patternsHeading: "Structuri cheie",
-          tipsHeading: "De reținut",
-          storyHeading: "Mini-poveste",
-          practiceHeading: "Exersează",
-          practice1Title: "Alege articolul corect",
-          practice1Body: "Atinge articolul potrivit.",
-          practice2Title: "kein sau keine?",
-          practice2Body: "Alege negația corectă.",
-          practice3Title: "Găsește pluralul",
-          practice3Body: "Atinge forma corectă.",
-          actionButton: "Rundă nouă",
-          footerNote: "Pașii mici aduc progres mare.",
-        },
-        sv: {
-          title: "Substantiv och artiklar",
-          lessonTag: "A1 · Lektion 1",
-          description: "Bestämda och obestämda artiklar, plural, negation med «kein/keine».",
-          badgeArticle: "Artiklar",
-          badgePlural: "Plural",
-          badgeNegation: "kein/keine",
-          patternsHeading: "Viktiga mönster",
-          tipsHeading: "Kom ihåg",
-          storyHeading: "Mini-berättelse",
-          practiceHeading: "Öva",
-          practice1Title: "Välj rätt artikel",
-          practice1Body: "Tryck på den rätta.",
-          practice2Title: "kein eller keine?",
-          practice2Body: "Välj rätt negation.",
-          practice3Title: "Hitta pluralen",
-          practice3Body: "Tryck på rätt form.",
-          actionButton: "Ny omgång",
-          footerNote: "Små steg ger stor utveckling.",
-        },
-        pt: {
-          title: "Substantivos e artigos",
-          lessonTag: "A1 · Lição 1",
-          description: "Artigos definidos e indefinidos, plural, negação com «kein/keine».",
-          badgeArticle: "Artigos",
-          badgePlural: "Plural",
-          badgeNegation: "kein/keine",
-          patternsHeading: "Padrões-chave",
-          tipsHeading: "Lembre-se",
-          storyHeading: "Mini-história",
-          practiceHeading: "Praticar",
-          practice1Title: "Escolha o artigo certo",
-          practice1Body: "Toque no artigo correto.",
-          practice2Title: "kein ou keine?",
-          practice2Body: "Escolha a negação certa.",
-          practice3Title: "Encontre o plural",
-          practice3Body: "Toque a forma correta.",
-          actionButton: "Nova rodada",
-          footerNote: "Pequenos passos geram grande progresso.",
-        },
-        ko: {
-          title: "명사와 관사",
-          lessonTag: "A1 · 1과",
-          description: "정관사·부정관사, 복수, kein/keine로 하는 부정.",
-          badgeArticle: "관사",
-          badgePlural: "복수",
-          badgeNegation: "kein/keine",
-          patternsHeading: "핵심 패턴",
-          tipsHeading: "기억해요",
-          storyHeading: "미니 스토리",
-          practiceHeading: "연습",
-          practice1Title: "맞는 관사를 고르세요",
-          practice1Body: "알맞은 관사를 누르세요.",
-          practice2Title: "kein? keine?",
-          practice2Body: "맞는 부정을 선택하세요.",
-          practice3Title: "복수형 찾기",
-          practice3Body: "올바른 형태를 누르세요.",
-          actionButton: "새 라운드",
-          footerNote: "작은 걸음이 큰 발전을 만듭니다.",
-        },
-        ja: {
-          title: "名詞と冠詞",
-          lessonTag: "A1 · レッスン1",
-          description: "定冠詞・不定冠詞、複数形、「kein/keine」での否定。",
-          badgeArticle: "冠詞",
-          badgePlural: "複数形",
-          badgeNegation: "kein/keine",
-          patternsHeading: "重要パターン",
-          tipsHeading: "覚えよう",
-          storyHeading: "ミニストーリー",
-          practiceHeading: "練習",
-          practice1Title: "正しい冠詞を選ぶ",
-          practice1Body: "合う冠詞をタップ。",
-          practice2Title: "kein それとも keine?",
-          practice2Body: "正しい否定を選ぶ。",
-          practice3Title: "複数形を探す",
-          practice3Body: "正しい形をタップ。",
-          actionButton: "新しいラウンド",
-          footerNote: "小さな一歩が大きな進歩につながる。",
-        },
-        nl: {
-          title: "Zelfstandige naamwoorden en lidwoorden",
-          lessonTag: "A1 · Les 1",
-          description: "Bepaalde en onbepaalde lidwoorden, meervoud, ontkenning met ‘kein/keine’.",
-          badgeArticle: "Lidwoorden",
-          badgePlural: "Meervoud",
-          badgeNegation: "kein/keine",
-          patternsHeading: "Belangrijke patronen",
-          tipsHeading: "Onthoud",
-          storyHeading: "Mini-verhaal",
-          practiceHeading: "Oefenen",
-          practice1Title: "Kies het juiste lidwoord",
-          practice1Body: "Tik op het juiste lidwoord.",
-          practice2Title: "kein of keine?",
-          practice2Body: "Kies de juiste ontkenning.",
-          practice3Title: "Vind het meervoud",
-          practice3Body: "Tik op de juiste vorm.",
-          actionButton: "Nieuwe ronde",
-          footerNote: "Kleine stappen zorgen voor grote vooruitgang.",
-        },
-        zh: {
-          title: "名词与冠词",
-          lessonTag: "A1 · 第1课",
-          description: "定冠词、不定冠词、复数形式以及“kein/keine”否定。",
-          badgeArticle: "冠词",
-          badgePlural: "复数",
-          badgeNegation: "kein/keine",
-          patternsHeading: "关键模式",
-          tipsHeading: "记住",
-          storyHeading: "迷你故事",
-          practiceHeading: "练习",
-          practice1Title: "选择正确的冠词",
-          practice1Body: "点击合适的冠词。",
-          practice2Title: "kein 还是 keine?",
-          practice2Body: "选择正确的否定。",
-          practice3Title: "找出复数",
-          practice3Body: "点击正确形式。",
-          actionButton: "重新开始",
-          footerNote: "一步一步，稳步提升。",
-        },
-        hr: {
-          title: "Imenice i članci",
-          lessonTag: "A1 · Lekcija 1",
-          description: "Određeni i neodređeni članci, množina, nijekanje s ‘kein/keine’.",
-          badgeArticle: "Članci",
-          badgePlural: "Množina",
-          badgeNegation: "kein/keine",
-          patternsHeading: "Ključni obrasci",
-          tipsHeading: "Zapamti",
-          storyHeading: "Mini priča",
-          practiceHeading: "Vježbaj",
-          practice1Title: "Odaberi točan član",
-          practice1Body: "Dodirni odgovarajući član.",
-          practice2Title: "kein ili keine?",
-          practice2Body: "Odaberi pravilnu negaciju.",
-          practice3Title: "Pronađi množinu",
-          practice3Body: "Dodirni točan oblik.",
-          actionButton: "Nova runda",
-          footerNote: "Mali koraci vode velikom napretku.",
-        },
-        hy: {
-          title: "Գոյականներ և հոդեր",
-          lessonTag: "A1 · Դաս 1",
-          description: "Սահմանված ու անորոշ հոդեր, բազմական, ժխտում «kein/keine»-ով։",
-          badgeArticle: "Հոդեր",
-          badgePlural: "Բազմական",
-          badgeNegation: "kein/keine",
-          patternsHeading: "Կարևոր ձևեր",
-          tipsHeading: "Հիշեք",
-          storyHeading: "Մինի պատմություն",
-          practiceHeading: "Վարժանք",
-          practice1Title: "Ընտրեք ճիշտ հոդը",
-          practice1Body: "Սեղմեք համապատասխան հոդի վրա։",
-          practice2Title: "kein թե keine?",
-          practice2Body: "Ընտրեք ճիշտ ժխտումը։",
-          practice3Title: "Գտեք բազմականը",
-          practice3Body: "Սեղմեք ճիշտ ձևը։",
-          actionButton: "Նոր փուլ",
-          footerNote: "Փոքր քայլերը բերում են մեծ առաջընթաց։",
-        },
-      };
+        const render = () => {
+          if (!items.length) return;
+          lock = false;
+          const item = items[index];
+          promptEl.textContent = item.prompt;
+          feedbackEl.textContent = "";
+          optionsEl.innerHTML = "";
 
-      const articleExercises = [
-        { word: "___ Tisch", correct: "der" },
-        { word: "___ Lampe", correct: "die" },
-        { word: "___ Buch", correct: "das" },
-        { word: "___ Stuhl", correct: "der" },
-        { word: "___ Wohnung", correct: "die" },
-      ];
-
-      const negationExercises = [
-        { word: "___ Bücher", correct: "keine" },
-        { word: "___ Brot", correct: "kein" },
-        { word: "___ Kinder", correct: "keine" },
-        { word: "___ Wasser", correct: "kein" },
-      ];
-
-      const pluralExercises = [
-        { word: "der Tisch", correct: "Tische", options: ["Tische", "Tischer", "Tischn"] },
-        { word: "die Lampe", correct: "Lampen", options: ["Lampen", "Lamper", "Lampe"] },
-        { word: "das Buch", correct: "Bücher", options: ["Bücher", "Buchs", "Büchern"] },
-        { word: "der Apfel", correct: "Äpfel", options: ["Äpfel", "Apfels", "Apfeln"] },
-      ];
-
-      const sample = (items) => items[Math.floor(Math.random() * items.length)];
-
-      const setProgress = (element, value) => {
-        requestAnimationFrame(() => {
-          element.style.width = `${value}%`;
-        });
-      };
-
-      const updateExercise = (config) => {
-        const {
-          wordElement,
-          chips,
-          progress,
-          generator,
-        } = config;
-        const exercise = generator();
-        wordElement.textContent = config.prefix ? `${config.prefix} ${exercise.word}` : exercise.word;
-        chips.forEach((chip, index) => {
-          chip.classList.remove("selected", "correct", "incorrect");
-          chip.disabled = false;
-          if (exercise.options) {
-            chip.textContent = exercise.options[index];
-            chip.dataset.answer = exercise.options[index];
-          }
-        });
-        config.current = exercise;
-        setProgress(progress, 0);
-      };
-
-      const attachLogic = () => {
-        const articleWord = document.getElementById("article-word");
-        const articleChips = Array.from(
-          document.querySelectorAll('[data-practice="articles"] .chip')
-        );
-        const articleProgress = document.getElementById("article-progress");
-
-        const negationWord = document.getElementById("negation-word");
-        const negationChips = Array.from(
-          document.querySelectorAll('[data-practice="negation"] .chip')
-        );
-        const negationProgress = document.getElementById("negation-progress");
-
-        const pluralWord = document.getElementById("plural-word");
-        const pluralChips = Array.from(
-          document.querySelectorAll('[data-practice="plural"] .chip')
-        );
-        const pluralProgress = document.getElementById("plural-progress");
-
-        const setups = [
-          {
-            chips: articleChips,
-            wordElement: articleWord,
-            progress: articleProgress,
-            generator: () => sample(articleExercises),
-          },
-          {
-            chips: negationChips,
-            wordElement: negationWord,
-            progress: negationProgress,
-            generator: () => sample(negationExercises),
-          },
-          {
-            chips: pluralChips,
-            wordElement: pluralWord,
-            progress: pluralProgress,
-            generator: () => {
-              const exercise = sample(pluralExercises);
-              const shuffled = [...exercise.options].sort(() => Math.random() - 0.5);
-              return { ...exercise, options: shuffled };
-            },
-          },
-        ];
-
-        setups.forEach((setup) => updateExercise(setup));
-
-        setups.forEach((setup) => {
-          setup.chips.forEach((chip) => {
-            chip.addEventListener("click", () => {
-              if (chip.disabled) return;
-              setup.chips.forEach((c) => c.classList.remove("selected"));
-              chip.classList.add("selected");
-              const answer = chip.dataset.answer || chip.textContent;
-              const isCorrect = answer.trim() === setup.current.correct;
-              chip.classList.add(isCorrect ? "correct" : "incorrect");
-              setup.chips.forEach((c) => (c.disabled = true));
-              setProgress(setup.progress, isCorrect ? 100 : 40);
-              setTimeout(() => updateExercise(setup), 1400);
+          item.options.forEach((option) => {
+            const button = document.createElement("button");
+            button.type = "button";
+            button.className = "option-button";
+            button.textContent = option;
+            button.addEventListener("click", () => {
+              if (lock) return;
+              lock = true;
+              const correct = option === item.answer;
+              if (correct) {
+                button.classList.add("is-correct");
+                feedbackEl.textContent = item.feedback || "Richtig!";
+                setTimeout(() => {
+                  index = (index + 1) % items.length;
+                  render();
+                }, 900);
+              } else {
+                button.classList.add("is-incorrect");
+                feedbackEl.textContent = item.hint || "Versuch es noch einmal.";
+                lock = false;
+              }
             });
+            optionsEl.appendChild(button);
           });
-        });
+        };
 
-        document.getElementById("refresh").addEventListener("click", () => {
-          setups.forEach((setup) => updateExercise(setup));
-        });
-      };
-
-      const applyLanguage = () => {
-        const params = new URLSearchParams(window.location.search);
-        const langParam = params.get("ln") || params.get("lang") || "";
-        const lang = langParam.toLowerCase();
-        const activeLang = supportedLanguages.includes(lang) ? lang : "en";
-        document.documentElement.lang = activeLang;
-        const messages = translations[activeLang] || translations.en;
-
-        document.querySelectorAll("[data-i18n]").forEach((element) => {
-          const key = element.dataset.i18n;
-          if (messages[key]) {
-            element.textContent = messages[key];
-          }
-        });
-
-        const badgeArticle = document.querySelector('[data-i18n="badgeArticle"]');
-        badgeArticle && (badgeArticle.lastChild.textContent = ` ${messages.badgeArticle || "Artikel"}`);
-        const badgePlural = document.querySelector('[data-i18n="badgePlural"]');
-        badgePlural && (badgePlural.lastChild.textContent = ` ${messages.badgePlural || "Plural"}`);
-        const badgeNegation = document.querySelector('[data-i18n="badgeNegation"]');
-        badgeNegation && (badgeNegation.lastChild.textContent = ` ${messages.badgeNegation || "kein/keine"}`);
-      };
-
-      applyLanguage();
-      attachLogic();
+        render();
+      });
     </script>
   </body>
 </html>

--- a/Lingo/Lingo_styles.css
+++ b/Lingo/Lingo_styles.css
@@ -1,0 +1,487 @@
+:root {
+  color-scheme: light;
+  --font-sans: "Inter", "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI",
+    Roboto, sans-serif;
+  --font-serif: "Source Serif Pro", "Georgia", serif;
+  --ink-900: #0f172a;
+  --ink-700: #1f2937;
+  --ink-500: rgba(15, 23, 42, 0.72);
+  --ink-300: rgba(15, 23, 42, 0.56);
+  --accent-500: #6366f1;
+  --accent-600: #4f46e5;
+  --accent-200: rgba(99, 102, 241, 0.18);
+  --accent-100: rgba(99, 102, 241, 0.12);
+  --mint-500: #10b981;
+  --rose-500: #f43f5e;
+  --amber-500: #f59e0b;
+  --surface: rgba(255, 255, 255, 0.92);
+  --surface-strong: rgba(255, 255, 255, 0.98);
+  --shadow-soft: 0 20px 45px rgba(15, 23, 42, 0.14);
+  --radius-large: 32px;
+  --radius-medium: 22px;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-sans);
+  background: radial-gradient(circle at 15% 20%, rgba(99, 102, 241, 0.12), transparent 55%),
+    radial-gradient(circle at 85% 15%, rgba(16, 185, 129, 0.12), transparent 60%),
+    linear-gradient(180deg, #f8fafc 0%, #eef2ff 45%, #e0f2fe 100%);
+  color: var(--ink-700);
+  -webkit-font-smoothing: antialiased;
+  padding: 40px 18px 96px;
+  display: flex;
+  justify-content: center;
+}
+
+main.app-shell {
+  width: min(1040px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 36px;
+}
+
+.hero {
+  position: relative;
+  padding: 46px clamp(28px, 6vw, 48px);
+  border-radius: var(--radius-large);
+  background: var(--surface);
+  box-shadow: var(--shadow-soft);
+  overflow: hidden;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 28px;
+  isolation: isolate;
+}
+
+.hero::before,
+.hero::after {
+  content: "";
+  position: absolute;
+  border-radius: 50%;
+  mix-blend-mode: screen;
+  pointer-events: none;
+  opacity: 0.85;
+}
+
+.hero::before {
+  inset: -140px auto auto -80px;
+  width: 280px;
+  height: 280px;
+  background: radial-gradient(circle, rgba(99, 102, 241, 0.25), transparent 70%);
+}
+
+.hero::after {
+  inset: auto -120px -160px auto;
+  width: 320px;
+  height: 320px;
+  background: radial-gradient(circle, rgba(16, 185, 129, 0.3), transparent 70%);
+}
+
+.hero-content {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 18px;
+}
+
+.level-chip {
+  align-self: start;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 18px;
+  border-radius: 999px;
+  font-size: 14px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--accent-600);
+  background: rgba(79, 70, 229, 0.12);
+}
+
+.hero h1 {
+  margin: 0;
+  font-size: clamp(32px, 5vw, 48px);
+  line-height: 1.05;
+  color: var(--ink-900);
+  letter-spacing: -0.02em;
+}
+
+.hero p {
+  margin: 0;
+  font-size: clamp(17px, 2vw, 19px);
+  line-height: 1.6;
+  color: var(--ink-500);
+}
+
+.hero-highlights {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 14px;
+  padding: 0;
+  margin: 12px 0 0;
+  list-style: none;
+}
+
+.hero-highlights li {
+  background: var(--surface-strong);
+  border-radius: var(--radius-medium);
+  padding: 16px 18px;
+  box-shadow: inset 0 0 0 1px rgba(79, 70, 229, 0.08);
+  display: grid;
+  gap: 6px;
+}
+
+.hero-highlights span {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--accent-600);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.hero-visual {
+  position: relative;
+  z-index: 1;
+  background: radial-gradient(circle at 30% 30%, rgba(99, 102, 241, 0.25), transparent 65%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.35) 0%, rgba(255, 255, 255, 0) 100%);
+  border-radius: 28px;
+  padding: 28px 24px;
+  box-shadow: inset 0 0 0 1px rgba(79, 70, 229, 0.08);
+  display: grid;
+  gap: 16px;
+}
+
+.hero-visual h2 {
+  margin: 0;
+  font-size: 18px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--accent-600);
+}
+
+.hero-visual .gender-row {
+  display: grid;
+  gap: 12px;
+}
+
+.hero-visual .gender-row div {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: 16px;
+  background: rgba(79, 70, 229, 0.08);
+  font-weight: 600;
+}
+
+.section {
+  background: var(--surface);
+  border-radius: var(--radius-large);
+  padding: clamp(28px, 5vw, 44px);
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 26px;
+}
+
+.section-header {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.section-title {
+  margin: 0;
+  font-size: clamp(24px, 3vw, 30px);
+  line-height: 1.2;
+  color: var(--ink-900);
+}
+
+.section-subtitle {
+  margin: 0;
+  font-size: 16px;
+  color: var(--ink-500);
+}
+
+.card-grid {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.card {
+  position: relative;
+  padding: 22px 22px 24px;
+  border-radius: var(--radius-medium);
+  background: var(--surface-strong);
+  box-shadow: inset 0 0 0 1px rgba(79, 70, 229, 0.05);
+  display: grid;
+  gap: 14px;
+  overflow: hidden;
+}
+
+.card::after {
+  content: "";
+  position: absolute;
+  inset: auto -60px -80px auto;
+  width: 160px;
+  height: 160px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(99, 102, 241, 0.18), transparent 65%);
+  pointer-events: none;
+}
+
+.card h3 {
+  margin: 0;
+  font-size: 20px;
+  letter-spacing: -0.01em;
+}
+
+.card p {
+  margin: 0;
+  font-size: 16px;
+  line-height: 1.6;
+  color: var(--ink-500);
+}
+
+.example-bubble {
+  align-self: start;
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-radius: 999px;
+  background: var(--accent-200);
+  color: var(--ink-900);
+  font-weight: 600;
+  font-size: 15px;
+}
+
+.example-bubble small {
+  font-weight: 500;
+  color: var(--ink-500);
+}
+
+.color-legend {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 14px;
+}
+
+.color-card {
+  position: relative;
+  padding: 18px 20px 20px;
+  border-radius: var(--radius-medium);
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(15, 23, 42, 0.05);
+  display: grid;
+  gap: 10px;
+}
+
+.color-pill {
+  width: fit-content;
+  padding: 10px 18px;
+  border-radius: 999px;
+  font-weight: 600;
+  color: white;
+  letter-spacing: 0.04em;
+}
+
+.color-pill[data-gender="m"] {
+  background: #1d4ed8;
+}
+
+.color-pill[data-gender="f"] {
+  background: #dc2626;
+}
+
+.color-pill[data-gender="n"] {
+  background: #059669;
+}
+
+.timeline {
+  display: grid;
+  gap: 18px;
+}
+
+.timeline-step {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 18px;
+  align-items: start;
+}
+
+.timeline-step span {
+  width: 40px;
+  height: 40px;
+  border-radius: 14px;
+  background: rgba(79, 70, 229, 0.16);
+  color: var(--accent-600);
+  font-weight: 700;
+  display: grid;
+  place-items: center;
+  font-size: 16px;
+}
+
+.timeline-step p {
+  margin: 0;
+  font-size: 16px;
+  line-height: 1.6;
+  color: var(--ink-500);
+}
+
+.practice-lab {
+  display: grid;
+  gap: 22px;
+}
+
+.practice-card {
+  padding: 24px;
+  border-radius: var(--radius-medium);
+  background: var(--surface-strong);
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.06);
+  display: grid;
+  gap: 16px;
+}
+
+.practice-card h3 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.practice-card p {
+  margin: 0;
+  color: var(--ink-500);
+  line-height: 1.5;
+}
+
+.practice-prompt {
+  font-size: 17px;
+  font-weight: 600;
+  color: var(--ink-900);
+  padding: 14px 18px;
+  border-radius: 16px;
+  background: rgba(79, 70, 229, 0.1);
+}
+
+.option-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.option-button {
+  flex: 1 1 120px;
+  padding: 12px 16px;
+  border-radius: 14px;
+  border: none;
+  background: rgba(79, 70, 229, 0.08);
+  color: var(--ink-700);
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
+}
+
+.option-button:focus-visible {
+  outline: 3px solid rgba(79, 70, 229, 0.4);
+  outline-offset: 3px;
+}
+
+.option-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px rgba(79, 70, 229, 0.2);
+}
+
+.option-button.is-correct {
+  background: rgba(16, 185, 129, 0.14);
+  color: var(--mint-500);
+}
+
+.option-button.is-incorrect {
+  background: rgba(244, 63, 94, 0.14);
+  color: var(--rose-500);
+}
+
+.practice-feedback {
+  font-size: 15px;
+  color: var(--ink-500);
+  min-height: 20px;
+}
+
+.quick-reference {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.reference-card {
+  padding: 18px 20px;
+  border-radius: var(--radius-medium);
+  background: rgba(15, 23, 42, 0.04);
+  display: grid;
+  gap: 10px;
+}
+
+.reference-card h4 {
+  margin: 0;
+  font-size: 17px;
+  color: var(--ink-900);
+}
+
+.reference-card ul {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--ink-500);
+  line-height: 1.5;
+}
+
+.footer-note {
+  font-size: 15px;
+  color: var(--ink-300);
+  text-align: center;
+}
+
+@media (min-width: 880px) {
+  .hero {
+    grid-template-columns: minmax(0, 1fr) 360px;
+    align-items: center;
+  }
+}
+
+@media (max-width: 640px) {
+  body {
+    padding: 28px 14px 72px;
+  }
+
+  .practice-card {
+    padding: 20px;
+  }
+
+  .hero {
+    padding: 36px 24px;
+  }
+}
+.hero-visual small {
+  color: var(--ink-500);
+  font-weight: 500;
+}
+
+.hero-visual strong {
+  font-family: var(--font-serif);
+  font-size: 36px;
+  color: var(--ink-900);
+}


### PR DESCRIPTION
## Summary
- add a standalone `Lingo_styles.css` with gradients, card layouts, and practice styling inspired by the reference images
- rebuild the `A1-1.html` lesson to use the new design, refreshed explanations, and lightweight practice interactions driven by the shared styles

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68d93d256f8c8328bbc37f7bf9264663