### PR TITLE
Fallback to English when requested target language file is unavailable

### DIFF
--- a/router/adminRouter.js
+++ b/router/adminRouter.js
@@ -152,7 +152,12 @@ adminRoutes.get("/getAll", (req, res) => {
   try {
     const DeData = readJsonFile(level, "de");
     const DeDataKeys = Object.keys(DeData);
-    const targetData = readJsonFile(level, targetLanguage);
+    let targetData;
+    try {
+      targetData = readJsonFile(level, targetLanguage);
+    } catch (error) {
+      targetData = readJsonFile(level, "en");
+    }
     
     if (DeDataKeys.length > 0 ) {
       const newArry = []


### PR DESCRIPTION
### Motivation
- Ensure `GET /getAll` returns usable translations when the requested `targetLanguage` is not supported by falling back to English (`en`).

### Description
- Updated `router/adminRouter.js` so `readJsonFile(level, targetLanguage)` is attempted inside a `try` and on error falls back to `readJsonFile(level, "en")` and the rest of the response construction is unchanged.

### Testing
- Ran a syntax check with `node -c router/adminRouter.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d51a2787ac8328ac639f68a16c43b0)