### PR TITLE
Fix Ukrainian lesson language selection and German fallback

### DIFF
--- a/Lingo/LingoApi.js
+++ b/Lingo/LingoApi.js
@@ -28,24 +28,25 @@ const SUPPORTED_LANGUAGES = new Set([
   "hy",
 ]);
 
-const DEFAULT_LANGUAGE = "en";
+const DEFAULT_LANGUAGE = "de";
 
 const pickLanguage = (ln) => {
   if (!ln || typeof ln !== "string") {
-    return { language: DEFAULT_LANGUAGE, fallbackToEnglish: true };
+    return { language: DEFAULT_LANGUAGE, fallbackToGerman: true };
   }
 
-  const normalized = ln.toLowerCase();
+  const normalizedRaw = ln.toLowerCase();
+  const normalized = normalizedRaw === "ua" ? "uk" : normalizedRaw;
   if (!SUPPORTED_LANGUAGES.has(normalized)) {
     return {
       language: DEFAULT_LANGUAGE,
-      fallbackToEnglish: true,
+      fallbackToGerman: true,
       unsupportedLanguage: ln,
       supported: Array.from(SUPPORTED_LANGUAGES).sort(),
     };
   }
 
-  return { language: normalized, fallbackToEnglish: false };
+  return { language: normalized, fallbackToGerman: false };
 };
 
 const readStructure = () => {
@@ -80,19 +81,19 @@ const withChapterUrls = (structure, language) => ({
 
 lingoRouter.get("/structure", (req, res) => {
   const { ln } = req.query;
-  const { language, fallbackToEnglish, unsupportedLanguage, supported } = pickLanguage(ln);
+  const { language, fallbackToGerman, unsupportedLanguage, supported } = pickLanguage(ln);
 
   try {
     const structure = withChapterUrls(readStructure(), language);
     res.json({
       ...structure,
       language,
-      ...(fallbackToEnglish
+      ...(fallbackToGerman
         ? {
-            fallbackToEnglish: true,
+            fallbackToGerman: true,
             ...(unsupportedLanguage
               ? {
-                  message: `Unsupported language code '${unsupportedLanguage}'. Returned English structure by default.`,
+                  message: `Unsupported language code '${unsupportedLanguage}'. Returned German structure by default.`,
                   supportedLanguages: supported,
                 }
               : {}),
@@ -106,7 +107,7 @@ lingoRouter.get("/structure", (req, res) => {
 
 lingoRouter.get("/chapters/:chapterId", (req, res) => {
   const { ln } = req.query;
-  const { language, fallbackToEnglish, unsupportedLanguage, supported } = pickLanguage(ln);
+  const { language, fallbackToGerman, unsupportedLanguage, supported } = pickLanguage(ln);
 
   try {
     const { chapterId } = req.params;
@@ -118,12 +119,12 @@ lingoRouter.get("/chapters/:chapterId", (req, res) => {
           language,
           level: { id: level.id, title: level.title },
           chapter,
-          ...(fallbackToEnglish
+          ...(fallbackToGerman
             ? {
-                fallbackToEnglish: true,
+                fallbackToGerman: true,
                 ...(unsupportedLanguage
                   ? {
-                      message: `Unsupported language code '${unsupportedLanguage}'. Returned English chapter by default.`,
+                      message: `Unsupported language code '${unsupportedLanguage}'. Returned German chapter by default.`,
                       supportedLanguages: supported,
                     }
                   : {}),

--- a/Lingo/i18n/A1-7-translations.js
+++ b/Lingo/i18n/A1-7-translations.js
@@ -2390,7 +2390,7 @@
     "hy",
   ].forEach((code) => {
     if (!data.translations[code]) {
-      data.translations[code] = data.translations.en;
+      data.translations[code] = data.translations[data.fallbackLanguage];
     }
   });
 


### PR DESCRIPTION
### Motivation
- Ukrainian users were served English lessons because the language picker did not normalize `ua` to the supported `uk` code and the API defaulted to English when a language was missing or unsupported. 
- The lesson translations should fall back to the configured lesson fallback language (German) rather than a hardcoded English copy.

### Description
- Normalize `ln=ua` to `uk` in `Lingo/LingoApi.js` so Ukrainian requests map to the supported code. 
- Change the API default language from English to German by setting `DEFAULT_LANGUAGE` to `de` and update fallback metadata from `fallbackToEnglish` to `fallbackToGerman`. 
- Update user-facing fallback messages to indicate that German content was returned when appropriate. 
- Fix A1-7 translation fallback in `Lingo/i18n/A1-7-translations.js` so missing translations use `data.fallbackLanguage` (German) instead of the hardcoded English translations.

### Testing
- Ran syntax checks on the modified files with `node --check Lingo/LingoApi.js` which succeeded. 
- Ran syntax checks on the modified translations file with `node --check Lingo/i18n/A1-7-translations.js` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1066d4f58483288c3c7f221ce6481d)